### PR TITLE
Revamp header and search with sequential dropdowns

### DIFF
--- a/src/components/Dropdown.css
+++ b/src/components/Dropdown.css
@@ -1,0 +1,98 @@
+.dropdown {
+  position: absolute;
+  top: 100%;
+  margin-top: 0.5rem;
+  background: #FFF7EB;
+  border: 1px solid #4CAF87;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  z-index: 50;
+  animation: fadeSlide 0.2s ease forwards;
+}
+.dropdown-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  font-family: 'Golos_Text', Helvetica, sans-serif;
+  color: #333;
+  white-space: nowrap;
+  transition: background 0.2s ease;
+}
+.dropdown-item:hover {
+  background: rgba(76,175,135,0.1);
+}
+.guest-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  gap: 1rem;
+}
+.guest-btn {
+  background: #4CAF87;
+  color: white;
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.guest-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.guest-count {
+  font-family: 'Golos_Text', Helvetica, sans-serif;
+  font-size: 1rem;
+  min-width: 24px;
+  text-align: center;
+}
+@keyframes fadeSlide {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Mobile modal styles */
+@media (max-width: 768px) {
+  .dropdown-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.4);
+    display: flex;
+    justify-content: flex-end;
+    flex-direction: column;
+    animation: fadeIn 0.3s ease forwards;
+    z-index: 50;
+  }
+  .dropdown-modal-content {
+    background: #FFF7EB;
+    border-top-left-radius: 1rem;
+    border-top-right-radius: 1rem;
+    padding: 1rem;
+    animation: slideUp 0.3s ease forwards;
+  }
+  .close-btn {
+    align-self: flex-end;
+    font-size: 1.5rem;
+    line-height: 1;
+    padding: 0.25rem 0.5rem;
+  }
+  @keyframes slideUp {
+    from { transform: translateY(100%); }
+    to { transform: translateY(0); }
+  }
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+}
+
+/* Hide scrollbars */
+.dropdown, .dropdown-modal-content {
+  overflow: hidden;
+}
+.dropdown::-webkit-scrollbar, .dropdown-modal-content::-webkit-scrollbar {
+  display: none;
+}

--- a/src/components/GuestsDropdown.tsx
+++ b/src/components/GuestsDropdown.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import './Dropdown.css';
+
+interface Props {
+  value: number;
+  onChange: (value: number) => void;
+  onClose: () => void;
+  isMobile: boolean;
+}
+
+const GuestsDropdown: React.FC<Props> = ({ value, onChange, onClose, isMobile }) => {
+  const increment = () => onChange(value + 1);
+  const decrement = () => onChange(Math.max(1, value - 1));
+
+  const controls = (
+    <div className="guest-controls">
+      <button className="guest-btn" onClick={decrement} disabled={value <= 1}>-</button>
+      <span className="guest-count">{value}</span>
+      <button className="guest-btn" onClick={increment}>+</button>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="dropdown-modal">
+        <div className="dropdown-modal-content">
+          <button className="close-btn" onClick={onClose}>×</button>
+          {controls}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dropdown dropdown-desktop" style={{ left: '66%' }}>
+      {controls}
+    </div>
+  );
+};
+
+export default GuestsDropdown;

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,13 @@
+.header-container {
+  background: #FFF7EB;
+  overflow: hidden;
+}
+.header-container::-webkit-scrollbar {
+  display: none;
+}
+.text-green {
+  color: #4CAF87;
+}
+.border-green {
+  border-color: #4CAF87;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,96 +1,36 @@
 import React, { useState, useEffect } from 'react';
+import './Header.css';
 import { Button } from './ui/button';
 import SearchBar from './SearchBar';
 
-export const Header: React.FC = () => {
+const Header: React.FC = () => {
   const [isScrolled, setIsScrolled] = useState(false);
 
   useEffect(() => {
-    const handleScroll = () => {
-      const scrollPosition = window.scrollY;
-      setIsScrolled(scrollPosition > 50);
-    };
-
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+    const handle = () => setIsScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', handle);
+    return () => window.removeEventListener('scroll', handle);
   }, []);
 
   return (
-    <header className={`sticky top-0 z-50 w-full bg-[#FFF7EB] border-b border-[#569b6f]/20 transition-all duration-300 ease-in-out ${isScrolled ? 'py-2 shadow-lg' : 'py-4 md:py-6'}`}>
-      <div className="container mx-auto px-4 md:px-6 lg:px-8">
-        {/* Desktop Layout - Logo and Search Bar Side by Side */}
-        <div className="hidden md:flex items-center justify-between">
-          {/* Left Side - Logo and Search Bar */}
-          <div className="flex items-center flex-1 max-w-4xl">
-            {/* Logo */}
-            <div className="flex-shrink-0 mr-6 lg:mr-8">
-              <div className={`relative transition-all duration-300 ease-in-out ${isScrolled ? 'w-[100px] h-[40px]' : 'w-[120px] md:w-[150px] lg:w-[169px] h-[45px] md:h-[55px] lg:h-[65px]'}`}>
-                <img
-                  className={`absolute top-0 left-0 transition-all duration-300 ease-in-out ${isScrolled ? 'w-8 h-[40px]' : 'w-10 md:w-12 lg:w-16 h-[45px] md:h-[55px] lg:h-[65px]'}`}
-                  alt="Polygon"
-                  src="https://c.animaapp.com/mdww1mm3xpw4UO/img/polygon-2.svg"
-                />
-                <div className={`absolute bg-[#FFF7EB] transition-all duration-300 ease-in-out ${isScrolled ? 'w-[90px] h-[18px] top-4 left-2' : 'w-[110px] md:w-[135px] lg:w-[156px] h-[20px] md:h-[25px] lg:h-[33px] top-5 md:top-6 lg:top-7 left-2 md:left-2.5 lg:left-[13px]'}`} />
-                <div className={`absolute [font-family:'Golos_Text',Helvetica] font-bold tracking-[0] leading-[normal] whitespace-nowrap transition-all duration-300 ease-in-out ${isScrolled ? 'w-[90px] top-3 left-2 text-[16px]' : 'w-[110px] md:w-[135px] lg:w-[156px] top-4 md:top-5 lg:top-6 left-2 md:left-2.5 lg:left-3 text-[20px] md:text-[25px] lg:text-[35px]'}`}>
-                  <span className="text-[#569b6f]">Temp</span>
-                  <span className="text-[#ffc369]">H</span>
-                  <span className="text-[#569b6f]">o</span>
-                </div>
-              </div>
-            </div>
-
-            {/* Search Bar */}
-            <div className="flex-1 max-w-2xl">
-              <SearchBar isScrolled={isScrolled} />
-            </div>
-          </div>
-
-          {/* Right Side - Navigation Buttons */}
-          <div className="flex items-center space-x-2 md:space-x-3 lg:space-x-4 flex-shrink-0 ml-6">
-            <Button className={`bg-[#ffc369] rounded-[20px] md:rounded-[22px] lg:rounded-[25px] [font-family:'Golos_Text',Helvetica] font-bold text-white hover:bg-[#e6af5e] transition-all duration-300 ease-in-out ${isScrolled ? 'h-[35px] w-[70px] text-[12px]' : 'h-[40px] md:h-[45px] lg:h-[50px] w-[80px] md:w-[100px] lg:w-[120px] text-[14px] md:text-[16px] lg:text-[18px]'}`}>
-              Login
-            </Button>
-            <Button className={`bg-[#569b6f] rounded-[20px] md:rounded-[22px] lg:rounded-[25px] [font-family:'Golos_Text',Helvetica] font-bold text-white hover:bg-[#4d8a63] transition-all duration-300 ease-in-out ${isScrolled ? 'h-[35px] w-[70px] text-[12px]' : 'h-[40px] md:h-[45px] lg:h-[50px] w-[80px] md:w-[100px] lg:w-[120px] text-[14px] md:text-[16px] lg:text-[18px]'}`}>
-              Menu
-            </Button>
-          </div>
+    <header
+      className={`header-container sticky top-0 z-50 w-full border-b border-green transition-all duration-300 ${isScrolled ? 'py-2 shadow-lg' : 'py-4'}`}
+    >
+      <div className={`max-w-7xl mx-auto flex items-center justify-between flex-nowrap px-4 transition-all duration-300 ${isScrolled ? 'scale-95' : ''}`}>
+        <div className="flex items-center flex-shrink-0 gap-2">
+          <img src="https://c.animaapp.com/mdww1mm3xpw4UO/img/polygon-2.svg" alt="logo" className="w-10 h-10" />
+          <span className="font-bold text-2xl whitespace-nowrap">
+            <span className="text-green">Temp</span>
+            <span className="text-[#ffc369]">H</span>
+            <span className="text-green">o</span>
+          </span>
         </div>
-
-        {/* Mobile Layout - Logo on Top, Search Bar Below */}
-        <div className="md:hidden">
-          {/* Logo Row */}
-          <div className="flex items-center justify-between mb-3">
-            <div className="flex-shrink-0">
-              <div className={`relative transition-all duration-300 ease-in-out ${isScrolled ? 'w-[100px] h-[35px]' : 'w-[120px] h-[45px]'}`}>
-                <img
-                  className={`absolute top-0 left-0 transition-all duration-300 ease-in-out ${isScrolled ? 'w-8 h-[35px]' : 'w-10 h-[45px]'}`}
-                  alt="Polygon"
-                  src="https://c.animaapp.com/mdww1mm3xpw4UO/img/polygon-2.svg"
-                />
-                <div className={`absolute bg-[#FFF7EB] transition-all duration-300 ease-in-out ${isScrolled ? 'w-[90px] h-[16px] top-3 left-2' : 'w-[110px] h-[20px] top-4 left-2'}`} />
-                <div className={`absolute [font-family:'Golos_Text',Helvetica] font-bold tracking-[0] leading-[normal] whitespace-nowrap transition-all duration-300 ease-in-out ${isScrolled ? 'w-[90px] top-2.5 left-2 text-[16px]' : 'w-[110px] top-3 left-2 text-[20px]'}`}>
-                  <span className="text-[#569b6f]">Temp</span>
-                  <span className="text-[#ffc369]">H</span>
-                  <span className="text-[#569b6f]">o</span>
-                </div>
-              </div>
-            </div>
-
-            {/* Mobile Navigation Buttons */}
-            <div className="flex items-center space-x-2 flex-shrink-0">
-              <Button className={`bg-[#ffc369] rounded-[20px] [font-family:'Golos_Text',Helvetica] font-bold text-white hover:bg-[#e6af5e] transition-all duration-300 ease-in-out ${isScrolled ? 'h-[30px] w-[60px] text-[11px]' : 'h-[35px] w-[70px] text-[12px]'}`}>
-                Login
-              </Button>
-              <Button className={`bg-[#569b6f] rounded-[20px] [font-family:'Golos_Text',Helvetica] font-bold text-white hover:bg-[#4d8a63] transition-all duration-300 ease-in-out ${isScrolled ? 'h-[30px] w-[60px] text-[11px]' : 'h-[35px] w-[70px] text-[12px]'}`}>
-                Menu
-              </Button>
-            </div>
-          </div>
-
-          {/* Search Bar Row */}
-          <div className="w-full">
-            <SearchBar isScrolled={isScrolled} isMobile={true} />
-          </div>
+        <div className="flex-1 mx-4">
+          <SearchBar isScrolled={isScrolled} />
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <Button className="bg-[#ffc369] text-white hover:bg-[#e6af5e]">Login</Button>
+          <Button className="bg-green text-white hover:bg-[#3d8b6e]">Menu</Button>
         </div>
       </div>
     </header>

--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -1,0 +1,14 @@
+.hero-button {
+  background: #4CAF87;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.hero-button:hover {
+  background: #3d8b6e;
+}
+.hero-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import './HeroSection.css';
+import { Button } from './ui/button';
+
+const HeroSection: React.FC = () => {
+  const scrollToServices = () => {
+    document.getElementById('services')?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <section className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[#fff7eb] flex items-center">
+      <div className="container text-center">
+        <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-4xl md:text-6xl lg:text-8xl tracking-[-2px] md:tracking-[-4px] lg:tracking-[-5.76px] leading-tight md:leading-[1.1] lg:leading-[84.3px] mb-6 md:mb-8 lg:mb-10">
+          Welcome To Your <br /> Canadian Dream
+        </h1>
+        <p className="w-full max-w-[522px] mx-auto [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-lg md:text-2xl lg:text-[32px] tracking-[-1px] md:tracking-[-1.5px] lg:tracking-[-1.92px] leading-relaxed md:leading-[1.2] lg:leading-[28.1px] mb-8 md:mb-10 lg:mb-12">
+          At the frontier of the living lavish lifestyle in Canada
+        </p>
+        <Button
+          onClick={scrollToServices}
+          className="hero-button rounded-[35px] md:rounded-[43px] text-white px-8 py-4 md:px-10 md:py-5 lg:px-12 lg:py-6"
+        >
+          Explore Our Listings
+          <span className="hero-arrow">
+            <img
+              src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-1.svg"
+              alt="Arrow forward"
+              className="w-5 h-5 md:w-6 md:h-6"
+            />
+          </span>
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default HeroSection;

--- a/src/components/LocationDropdown.tsx
+++ b/src/components/LocationDropdown.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { MapPin } from 'lucide-react';
+import './Dropdown.css';
+
+interface Props {
+  onSelect: (location: string) => void;
+  onClose: () => void;
+  isMobile: boolean;
+}
+
+const locations = [
+  'Toronto, Canada',
+  'Vancouver, Canada',
+  'Montreal, Canada',
+  'Calgary, Canada',
+  'Ottawa, Canada'
+];
+
+const LocationDropdown: React.FC<Props> = ({ onSelect, onClose, isMobile }) => {
+  const handleSelect = (loc: string) => {
+    onSelect(loc);
+  };
+
+  if (isMobile) {
+    return (
+      <div className="dropdown-modal">
+        <div className="dropdown-modal-content">
+          <button className="close-btn" onClick={onClose}>×</button>
+          {locations.map((loc) => (
+            <button key={loc} className="dropdown-item" onClick={() => handleSelect(loc)}>
+              <MapPin className="w-4 h-4 mr-2" />
+              {loc}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dropdown dropdown-desktop left-0">
+      {locations.map((loc) => (
+        <button key={loc} className="dropdown-item" onClick={() => handleSelect(loc)}>
+          <MapPin className="w-4 h-4 mr-2" />
+          {loc}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default LocationDropdown;

--- a/src/components/PriceDropdown.tsx
+++ b/src/components/PriceDropdown.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import './Dropdown.css';
+
+interface Props {
+  onSelect: (price: string) => void;
+  onClose: () => void;
+  isMobile: boolean;
+}
+
+const prices = [
+  'Any price',
+  '$500 - $1,000',
+  '$1,000 - $2,000',
+  '$2,000 - $3,000',
+  '$3,000+'
+];
+
+const PriceDropdown: React.FC<Props> = ({ onSelect, onClose, isMobile }) => {
+  const handleSelect = (p: string) => {
+    onSelect(p);
+  };
+
+  if (isMobile) {
+    return (
+      <div className="dropdown-modal">
+        <div className="dropdown-modal-content">
+          <button className="close-btn" onClick={onClose}>×</button>
+          {prices.map((p) => (
+            <button key={p} className="dropdown-item" onClick={() => handleSelect(p)}>
+              {p}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dropdown dropdown-desktop" style={{ left: '33%' }}>
+      {prices.map((p) => (
+        <button key={p} className="dropdown-item" onClick={() => handleSelect(p)}>
+          {p}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default PriceDropdown;

--- a/src/components/SearchBar.css
+++ b/src/components/SearchBar.css
@@ -1,0 +1,37 @@
+.border-green {
+  border-color: #4CAF87;
+}
+.section {
+  padding: 0 12px;
+}
+.section-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #4CAF87;
+  margin-right: 4px;
+  white-space: nowrap;
+}
+.section-value {
+  font-size: 0.875rem;
+  color: #333;
+  font-family: 'Golos_Text', Helvetica, sans-serif;
+  white-space: nowrap;
+}
+.search-button {
+  background-color: #4CAF87;
+}
+.search-button:hover {
+  background-color: #3d8b6e;
+}
+.search-button-active {
+  background-color: #4CAF87;
+}
+.search-overlay {
+  transition: opacity 0.3s ease;
+}
+.no-scrollbar {
+  overflow: hidden;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,238 +1,104 @@
-import React, { useState } from 'react';
-import { Button } from './ui/button';
-import { Input } from './ui/input';
+import React, { useState, useEffect } from 'react';
+import './SearchBar.css';
+import LocationDropdown from './LocationDropdown';
+import PriceDropdown from './PriceDropdown';
+import GuestsDropdown from './GuestsDropdown';
 
 interface SearchBarProps {
   isScrolled: boolean;
-  isMobile?: boolean;
-  className?: string;
 }
 
-export const SearchBar: React.FC<SearchBarProps> = ({ 
-  isScrolled, 
-  isMobile = false, 
-  className = '' 
-}) => {
-  const [searchData, setSearchData] = useState({
-    location: '',
-    price: '',
-    guests: 1
-  });
-  const [activeField, setActiveField] = useState<string | null>(null);
+export const SearchBar: React.FC<SearchBarProps> = ({ isScrolled }) => {
+  const [location, setLocation] = useState('');
+  const [price, setPrice] = useState('');
+  const [guests, setGuests] = useState(1);
+  const [active, setActive] = useState<null | 'location' | 'price' | 'guests'>(null);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth <= 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  const handleLocationSelect = (loc: string) => {
+    setLocation(loc);
+    setActive('price');
+  };
+
+  const handlePriceSelect = (p: string) => {
+    setPrice(p);
+    setActive('guests');
+  };
+
+  const handleGuestsChange = (count: number) => {
+    setGuests(count);
+  };
+
+  const closeDropdown = () => setActive(null);
 
   const handleSearch = () => {
-    console.log('Search triggered:', searchData);
-    // Add search logic here
+    console.log('Search triggered:', { location, price, guests });
+    closeDropdown();
   };
 
-  const handleInputChange = (field: string, value: string | number) => {
-    setSearchData(prev => ({
-      ...prev,
-      [field]: value
-    }));
-  };
-
-  const formatGuestText = (count: number) => {
-    if (count === 1) return '1 guest';
-    return `${count} guests`;
-  };
-
-  // Mobile layout
-  if (isMobile) {
-    return (
-      <div className={`w-full transition-all duration-300 ease-in-out ${className}`}>
-        <div className={`bg-white rounded-full border-2 border-[#569b6f]/30 shadow-md hover:shadow-lg transition-all duration-300 ease-in-out ${isScrolled ? 'h-10' : 'h-12'}`}>
-          <div className="flex items-center h-full px-3">
-            {/* Compact Location Input */}
-            <div className="flex-1 mr-2">
-              <Input
-                type="text"
-                placeholder="Where to?"
-                value={searchData.location}
-                onChange={(e) => handleInputChange('location', e.target.value)}
-                className={`border-none bg-transparent p-0 h-auto [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}
-                aria-label="Search location"
-              />
-            </div>
-
-            {/* Guest Counter */}
-            <div className="flex items-center space-x-1 mr-2">
-              <button
-                onClick={() => handleInputChange('guests', Math.max(1, searchData.guests - 1))}
-                className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                disabled={searchData.guests <= 1}
-                aria-label="Decrease guest count"
-              >
-                <span className="text-[#569b6f] text-xs">−</span>
-              </button>
-              <span className={`[font-family:'Golos_Text',Helvetica] font-medium text-[#569b6f] min-w-[15px] text-center transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                {searchData.guests}
-              </span>
-              <button
-                onClick={() => handleInputChange('guests', Math.min(16, searchData.guests + 1))}
-                className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                aria-label="Increase guest count"
-              >
-                <span className="text-[#569b6f] text-xs">+</span>
-              </button>
-            </div>
-
-            {/* Search Button */}
-            <Button
-              onClick={handleSearch}
-              className={`rounded-full bg-[#569b6f] hover:bg-[#4d8a63] text-white [font-family:'Golos_Text',Helvetica] font-bold shadow-md hover:shadow-lg transition-all duration-300 ease-in-out p-0 ${isScrolled ? 'h-6 w-6' : 'h-8 w-8'}`}
-              aria-label="Search properties"
-            >
-              <svg className={`transition-all duration-300 ease-in-out ${isScrolled ? 'w-3 h-3' : 'w-4 h-4'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-            </Button>
-          </div>
-        </div>
-
-        {/* Mobile Price Input Below */}
-        {!isScrolled && (
-          <div className="mt-2">
-            <Input
-              type="text"
-              placeholder="Price range (e.g., $1000-$2000)"
-              value={searchData.price}
-              onChange={(e) => handleInputChange('price', e.target.value)}
-              className="w-full bg-white border-2 border-[#569b6f]/30 rounded-full px-4 py-2 [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 text-sm"
-              aria-label="Price range"
-            />
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // Desktop layout
   return (
-    <div className={`relative transition-all duration-300 ease-in-out ${className}`}>
-      <div className={`bg-white rounded-full border-2 border-[#569b6f]/30 shadow-md hover:shadow-lg transition-all duration-300 ease-in-out ${isScrolled ? 'h-12' : 'h-16'}`}>
-        <div className="flex items-center h-full">
-          {/* Location Input */}
-          <div className="flex-1 px-4 md:px-6 border-r border-[#569b6f]/20">
-            <div className="flex flex-col justify-center h-full">
-              <label className={`text-[#569b6f] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                Where
-              </label>
-              <Input
-                type="text"
-                placeholder="Search destinations"
-                value={searchData.location}
-                onChange={(e) => handleInputChange('location', e.target.value)}
-                onFocus={() => setActiveField('location')}
-                onBlur={() => setActiveField(null)}
-                className={`border-none bg-transparent p-0 h-auto [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}
-                aria-label="Search location"
-              />
-            </div>
-          </div>
-
-          {/* Price Input */}
-          <div className="flex-1 px-4 md:px-6 border-r border-[#569b6f]/20">
-            <div className="flex flex-col justify-center h-full">
-              <label className={`text-[#569b6f] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                Price Range
-              </label>
-              <Input
-                type="text"
-                placeholder="Any price"
-                value={searchData.price}
-                onChange={(e) => handleInputChange('price', e.target.value)}
-                onFocus={() => setActiveField('price')}
-                onBlur={() => setActiveField(null)}
-                className={`border-none bg-transparent p-0 h-auto [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}
-                aria-label="Price range"
-              />
-            </div>
-          </div>
-
-          {/* Guests Input */}
-          <div className="flex-1 px-4 md:px-6">
-            <div className="flex flex-col justify-center h-full">
-              <label className={`text-[#569b6f] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                Guests
-              </label>
-              <div className="flex items-center space-x-2">
-                <button
-                  onClick={() => handleInputChange('guests', Math.max(1, searchData.guests - 1))}
-                  className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                  disabled={searchData.guests <= 1}
-                  aria-label="Decrease guest count"
-                >
-                  <span className="text-[#569b6f] text-sm">−</span>
-                </button>
-                <span className={`[font-family:'Golos_Text',Helvetica] font-medium text-gray-700 min-w-[20px] text-center transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}>
-                  {searchData.guests}
-                </span>
-                <button
-                  onClick={() => handleInputChange('guests', Math.min(16, searchData.guests + 1))}
-                  className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                  aria-label="Increase guest count"
-                >
-                  <span className="text-[#569b6f] text-sm">+</span>
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Search Button */}
-          <div className="pr-2">
-            <Button
-              onClick={handleSearch}
-              className={`rounded-full bg-[#569b6f] hover:bg-[#4d8a63] text-white [font-family:'Golos_Text',Helvetica] font-bold shadow-md hover:shadow-lg transition-all duration-300 ease-in-out p-0 ${isScrolled ? 'h-8 w-8' : 'h-12 w-12'}`}
-              aria-label="Search properties"
-            >
-              <svg className={`transition-all duration-300 ease-in-out ${isScrolled ? 'w-4 h-4' : 'w-5 h-5'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-            </Button>
-          </div>
+    <div className="relative w-full">
+      <div className={`flex items-center bg-white rounded-full shadow-md border-2 border-green transition-all duration-300 overflow-hidden ${isScrolled ? 'py-2 px-4 scale-90' : 'py-3 px-6'}`}>
+        <div className="flex-1 flex items-center section cursor-pointer" onClick={() => setActive('location')}>
+          <span className="section-label">Where</span>
+          <span className="section-value">{location || 'Add location'}</span>
         </div>
+        <div className="flex-1 flex items-center section cursor-pointer" onClick={() => setActive('price')}>
+          <span className="section-label">Price</span>
+          <span className="section-value">{price || 'Any price'}</span>
+        </div>
+        <div className="flex-1 flex items-center section cursor-pointer" onClick={() => setActive('guests')}>
+          <span className="section-label">Guests</span>
+          <span className="section-value">{guests} {guests === 1 ? 'guest' : 'guests'}</span>
+        </div>
+        <button
+          onClick={handleSearch}
+          className={`search-button flex items-center justify-center rounded-full text-white transition-all duration-300 ${active ? 'px-4 search-button-active' : 'px-3'}`}
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          {active && <span className="ml-2 font-semibold">Search</span>}
+        </button>
       </div>
 
-      {/* Desktop Dropdown Suggestions (shown when focused) */}
-      {activeField === 'location' && !isScrolled && (
-        <div className="absolute top-full left-0 mt-2 w-80 bg-white rounded-2xl shadow-xl border border-[#569b6f]/20 p-4 z-50">
-          <div className="space-y-2">
-            <div className="text-xs font-semibold text-[#569b6f] uppercase tracking-wide [font-family:'Golos_Text',Helvetica]">Popular destinations</div>
-            {['Toronto, ON', 'Vancouver, BC', 'Montreal, QC', 'Calgary, AB'].map((city) => (
-              <button
-                key={city}
-                className="block w-full text-left px-3 py-2 rounded-lg hover:bg-[#569b6f]/5 text-sm [font-family:'Golos_Text',Helvetica] transition-colors"
-                onClick={() => {
-                  handleInputChange('location', city);
-                  setActiveField(null);
-                }}
-              >
-                {city}
-              </button>
-            ))}
-          </div>
-        </div>
+      {active === 'location' && (
+        <LocationDropdown
+          onSelect={handleLocationSelect}
+          onClose={closeDropdown}
+          isMobile={isMobile}
+        />
       )}
 
-      {activeField === 'price' && !isScrolled && (
-        <div className="absolute top-full left-1/3 mt-2 w-64 bg-white rounded-2xl shadow-xl border border-[#569b6f]/20 p-4 z-50">
-          <div className="space-y-2">
-            <div className="text-xs font-semibold text-[#569b6f] uppercase tracking-wide [font-family:'Golos_Text',Helvetica]">Price ranges</div>
-            {['$500 - $1000', '$1000 - $1500', '$1500 - $2000', '$2000+'].map((range) => (
-              <button
-                key={range}
-                className="block w-full text-left px-3 py-2 rounded-lg hover:bg-[#569b6f]/5 text-sm [font-family:'Golos_Text',Helvetica] transition-colors"
-                onClick={() => {
-                  handleInputChange('price', range);
-                  setActiveField(null);
-                }}
-              >
-                {range}
-              </button>
-            ))}
-          </div>
-        </div>
+      {active === 'price' && (
+        <PriceDropdown
+          onSelect={handlePriceSelect}
+          onClose={closeDropdown}
+          isMobile={isMobile}
+        />
+      )}
+
+      {active === 'guests' && (
+        <GuestsDropdown
+          value={guests}
+          onChange={handleGuestsChange}
+          onClose={closeDropdown}
+          isMobile={isMobile}
+        />
+      )}
+
+      {active && (
+        <div
+          className={`search-overlay fixed inset-0 bg-black/40 transition-opacity duration-300 z-40 ${active ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+          onClick={closeDropdown}
+        />
       )}
     </div>
   );

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -4,7 +4,7 @@ import { PropertyCarousels } from './PropertyCarousels';
 
 export const ServicesSection: React.FC = () => {
   return (
-    <section className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[url(https://c.animaapp.com/mdww1mm3xpw4UO/img/rectangle-56.svg)] bg-cover bg-center bg-no-repeat">
+    <section id="services" className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[url(https://c.animaapp.com/mdww1mm3xpw4UO/img/rectangle-56.svg)] bg-cover bg-center bg-no-repeat">
       <div className="container py-8 md:py-10 lg:py-12">
         {/* Section Header */}
         <div className="flex items-center mb-6 md:mb-8">

--- a/src/screens/House/House.tsx
+++ b/src/screens/House/House.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { Badge } from "../../components/ui/badge";
-import { Button } from "../../components/ui/button";
-import { Card, CardContent } from "../../components/ui/card";
-import { Input } from "../../components/ui/input";
 import { ServicesSection } from "../../components/ServicesSection";
 import Header from "../../components/Header";
+import HeroSection from "../../components/HeroSection";
 
 export const House = (): JSX.Element => {
   return (
@@ -14,86 +12,7 @@ export const House = (): JSX.Element => {
         <Header />
 
         {/* Hero Section */}
-        <section className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[#fff7eb]">
-          <div className="container h-full">
-            <div className="flex flex-col lg:flex-row items-center lg:items-start h-full">
-              {/* Hero Content */}
-              <div className="flex-1 pt-16 md:pt-24 lg:pt-40 text-center lg:text-left">
-                <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-4xl md:text-6xl lg:text-8xl tracking-[-2px] md:tracking-[-4px] lg:tracking-[-5.76px] leading-tight md:leading-[1.1] lg:leading-[84.3px] mb-6 md:mb-8 lg:mb-10">
-                  Welcome To Your <br />
-                  Canadian Dream
-                </h1>
-                <p className="w-full max-w-[400px] md:max-w-[500px] lg:max-w-[522px] mx-auto lg:mx-0 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-lg md:text-2xl lg:text-[32px] tracking-[-1px] md:tracking-[-1.5px] lg:tracking-[-1.92px] leading-relaxed md:leading-[1.2] lg:leading-[28.1px] mb-8 md:mb-10 lg:mb-12">
-                  At the frontier of the living lavish lifestyle in Canada
-                </p>
-                
-                <Button className="relative h-[55px] md:h-[65px] lg:h-[72px] w-[280px] md:w-[300px] lg:w-[328px] bg-[#569b6f] rounded-[30px] md:rounded-[35px] lg:rounded-[43px] [font-family:'Golos_Text',Helvetica] font-medium text-white text-lg md:text-xl lg:text-2xl tracking-[-1px] md:tracking-[-1.2px] lg:tracking-[-1.44px] hover:bg-[#4d8a63] transition-colors overflow-hidden">
-                  <span className="relative z-10">Explore Our Service</span>
-                  <div className="absolute w-[45px] md:w-[55px] lg:w-[62px] h-[45px] md:h-[55px] lg:h-[62px] top-[5px] right-[5px] bg-white rounded-[25px] md:rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
-                    <img
-                      className="w-[20px] md:w-[25px] lg:w-[30px] h-[20px] md:h-[25px] lg:h-[30px]"
-                      alt="Arrow forward"
-                      src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-1.svg"
-                    />
-                  </div>
-                </Button>
-              </div>
-
-              {/* Hero Image Section - Hidden on mobile, visible on large screens */}
-              <div className="relative w-full max-w-[600px] lg:max-w-[722px] h-[400px] md:h-[600px] lg:h-[864px] mt-8 lg:mt-[109px] hidden md:block">
-                <div className="absolute w-[70%] lg:w-[573px] h-full lg:h-[864px] top-0 left-[15%] lg:left-[113px] bg-[#ffc3698c] rounded-[200px_200px_0px_0px] lg:rounded-[300px_300px_0px_0px]" />
-                <img
-                  className="absolute w-[60%] lg:w-[504px] h-[85%] lg:h-[792px] top-4 lg:top-9 left-[20%] lg:left-[146px] object-cover"
-                  alt="Luxury home"
-                  src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group.png"
-                />
-
-                {/* Floating Cards - Only visible on large screens */}
-                <Card className="absolute w-60 lg:w-72 h-[200px] lg:h-[257px] top-[100px] lg:top-[135px] right-0 lg:left-[434px] hidden lg:block">
-                  <CardContent className="p-0">
-                    <div className="relative w-full h-[60px] lg:h-[75px] bg-white rounded-[20px_20px_0px_0px] border border-solid border-black">
-                      <div className="absolute top-[20px] lg:top-[25px] left-[25px] lg:left-[35px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px] whitespace-nowrap">
-                        Vast Gallery
-                      </div>
-                      <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-[7px] lg:top-[9px] right-[7px] lg:left-[215px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
-                        <img
-                          className="w-8 lg:w-10 h-8 lg:h-10"
-                          alt="Arrow forward"
-                          src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-2.svg"
-                        />
-                      </div>
-                    </div>
-                    <img
-                      className="w-full h-[140px] lg:h-[182px] object-cover"
-                      alt="Gallery preview"
-                      src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-2.png"
-                    />
-                  </CardContent>
-                </Card>
-
-                <Card className="absolute w-60 lg:w-[292px] h-[110px] lg:h-[139px] top-[350px] lg:top-[523px] left-0 hidden lg:block">
-                  <CardContent className="p-0">
-                    <div className="relative w-full h-full bg-white rounded-[20px] border border-solid border-black p-4 lg:p-6">
-                      <div className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px]">
-                        Revenue
-                      </div>
-                      <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-2 lg:top-2.5 right-2 lg:left-[207px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
-                        <img
-                          className="w-8 lg:w-10 h-8 lg:h-10"
-                          alt="Arrow forward"
-                          src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward.svg"
-                        />
-                      </div>
-                      <div className="mt-2 [font-family:'Golos_Text',Helvetica] font-medium text-black text-3xl lg:text-5xl tracking-[-2px] lg:tracking-[-2.88px] leading-[1.1] lg:leading-[50.6px]">
-                        150K+
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            </div>
-          </div>
-        </section>
+        <HeroSection />
 
         {/* About Us Section */}
         <section className="w-full bg-white">


### PR DESCRIPTION
## Summary
- Add sticky header that scales on scroll and keeps logo inline.
- Redesign search bar into three-stage flow with location, price, and guests dropdowns and mobile-friendly modals.
- Introduce hero section button that scrolls smoothly to services listings.

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d94ca4f98832692587c5a2a3eeda6