### PR TITLE
Implement sticky header and guided search dropdowns

### DIFF
--- a/src/components/Dropdown.css
+++ b/src/components/Dropdown.css
@@ -1,0 +1,45 @@
+.dropdown {
+  @apply absolute mt-2 bg-white rounded-2xl shadow-xl border border-[#569b6f]/20 p-4 z-50 overflow-hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  animation: fade-slide .2s ease forwards;
+}
+.dropdown::-webkit-scrollbar { display: none; }
+.dropdown-list { @apply space-y-2; }
+.dropdown-item {
+  @apply flex items-center px-3 py-2 rounded-lg text-sm text-gray-700 cursor-pointer transition-colors;
+}
+.dropdown-item:hover { @apply bg-[#4CAF87]/10; }
+
+.guest-controls {
+  @apply flex items-center space-x-4;
+}
+.guest-btn {
+  @apply rounded-full border border-[#569b6f]/30 w-8 h-8 flex items-center justify-center text-[#569b6f] transition-colors;
+}
+.guest-btn:hover { @apply border-[#4CAF87] bg-[#4CAF87]/10; }
+.guest-btn:disabled { @apply opacity-40 cursor-not-allowed; }
+.guest-count { @apply text-gray-700 font-medium; }
+
+.mobile-modal {
+  @apply fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl p-6 z-50;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  animation: slide-up .3s ease forwards;
+}
+.mobile-modal::-webkit-scrollbar { display: none; }
+.modal-close {
+  @apply absolute top-3 right-4 text-2xl text-gray-500;
+}
+
+@keyframes fade-slide {
+  from { opacity:0; transform: translateY(-10px); }
+  to { opacity:1; transform: translateY(0); }
+}
+.animate-fade-slide { animation: fade-slide .2s ease forwards; }
+
+@keyframes slide-up {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+.animate-slide-up { animation: slide-up .3s ease forwards; }

--- a/src/components/GuestsDropdown.tsx
+++ b/src/components/GuestsDropdown.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import './Dropdown.css';
+
+interface GuestsDropdownProps {
+  value: number;
+  onChange: (count: number) => void;
+  onClose: () => void;
+  isMobile?: boolean;
+}
+
+const GuestsDropdown: React.FC<GuestsDropdownProps> = ({ value, onChange, onClose, isMobile = false }) => {
+  const decrement = () => {
+    if (value > 1) onChange(value - 1);
+  };
+  const increment = () => onChange(value + 1);
+
+  const content = (
+    <div className="guest-controls">
+      <button className="guest-btn" onClick={decrement} disabled={value <= 1}>
+        −
+      </button>
+      <span className="guest-count">{value}</span>
+      <button className="guest-btn" onClick={increment}>
+        +
+      </button>
+    </div>
+  );
+
+  return isMobile ? (
+    <div className="mobile-modal">
+      <button className="modal-close" onClick={onClose}>
+        &times;
+      </button>
+      {content}
+    </div>
+  ) : (
+    <div className="dropdown">{content}</div>
+  );
+};
+
+export default GuestsDropdown;

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,6 @@
+.sticky-header {
+  @apply overflow-hidden w-full bg-[#FFF7EB];
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.sticky-header::-webkit-scrollbar { display: none; }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from './ui/button';
 import SearchBar from './SearchBar';
+import './Header.css';
 
 export const Header: React.FC = () => {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -16,10 +17,10 @@ export const Header: React.FC = () => {
   }, []);
 
   return (
-    <header className={`sticky top-0 z-50 w-full bg-[#FFF7EB] border-b border-[#569b6f]/20 transition-all duration-300 ease-in-out ${isScrolled ? 'py-2 shadow-lg' : 'py-4 md:py-6'}`}>
+    <header className={`sticky-header sticky top-0 z-50 border-b border-[#569b6f]/20 transition-all duration-300 ease-in-out ${isScrolled ? 'py-2 shadow-lg scale-95' : 'py-4 md:py-6 scale-100'}`}>
       <div className="container mx-auto px-4 md:px-6 lg:px-8">
         {/* Desktop Layout - Logo and Search Bar Side by Side */}
-        <div className="hidden md:flex items-center justify-between">
+        <div className="hidden md:flex items-center justify-between flex-nowrap">
           {/* Left Side - Logo and Search Bar */}
           <div className="flex items-center flex-1 max-w-4xl">
             {/* Logo */}

--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -1,0 +1,8 @@
+.hero-button {
+  @apply relative bg-[#569b6f] text-white rounded-[30px] md:rounded-[35px] lg:rounded-[43px] font-medium hover:bg-[#4d8a63] transition-colors overflow-hidden;
+  padding-right: 4.5rem;
+}
+.hero-button .arrow-container {
+  @apply absolute top-1/2 -translate-y-1/2 right-4 bg-white rounded-full flex items-center justify-center w-[45px] h-[45px] md:w-[55px] md:h-[55px] lg:w-[62px] lg:h-[62px];
+}
+.hero-button:hover .arrow-container { @apply bg-white; }

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Button } from './ui/button';
+import './HeroSection.css';
+
+export const HeroSection: React.FC = () => {
+  const scrollToServices = () => {
+    const el = document.getElementById('services');
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+  return (
+    <section className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[#fff7eb]">
+      <div className="container h-full">
+        <div className="flex flex-col lg:flex-row items-center lg:items-start h-full">
+          {/* Hero Content */}
+          <div className="flex-1 pt-16 md:pt-24 lg:pt-40 text-center lg:text-left">
+            <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-4xl md:text-6xl lg:text-8xl tracking-[-2px] md:tracking-[-4px] lg:tracking-[-5.76px] leading-tight md:leading-[1.1] lg:leading-[84.3px] mb-6 md:mb-8 lg:mb-10">
+              Welcome To Your <br />
+              Canadian Dream
+            </h1>
+            <p className="w-full max-w-[400px] md:max-w-[500px] lg:max-w-[522px] mx-auto lg:mx-0 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-lg md:text-2xl lg:text-[32px] tracking-[-1px] md:tracking-[-1.5px] lg:tracking-[-1.92px] leading-relaxed md:leading-[1.2] lg:leading-[28.1px] mb-8 md:mb-10 lg:mb-12">
+              At the frontier of the living lavish lifestyle in Canada
+            </p>
+
+            <Button onClick={scrollToServices} className="hero-button h-[55px] md:h-[65px] lg:h-[72px] w-[280px] md:w-[300px] lg:w-[328px]">
+              Explore Our Listings
+              <div className="arrow-container">
+                <img
+                  className="w-[20px] md:w-[25px] lg:w-[30px] h-[20px] md:h-[25px] lg:h-[30px]"
+                  alt="Arrow forward"
+                  src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-1.svg"
+                />
+              </div>
+            </Button>
+          </div>
+
+          {/* Hero Image Section */}
+          <div className="relative w-full max-w-[600px] lg:max-w-[722px] h-[400px] md:h-[600px] lg:h-[864px] mt-8 lg:mt-[109px] hidden md:block">
+            <div className="absolute w-[70%] lg:w-[573px] h-full lg:h-[864px] top-0 left-[15%] lg:left-[113px] bg-[#ffc3698c] rounded-[200px_200px_0px_0px] lg:rounded-[300px_300px_0px_0px]" />
+            <img
+              className="absolute w-[60%] lg:w-[504px] h-[85%] lg:h-[792px] top-4 lg:top-9 left-[20%] lg:left-[146px] object-cover"
+              alt="Luxury home"
+              src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group.png"
+            />
+
+            {/* Floating Cards - Only visible on large screens */}
+            <div className="absolute w-60 lg:w-72 h-[200px] lg:h-[257px] top-[100px] lg:top-[135px] right-0 lg:left-[434px] hidden lg:block">
+              <div className="relative w-full h-[60px] lg:h-[75px] bg-white rounded-[20px_20px_0px_0px] border border-solid border-black">
+                <div className="absolute top-[20px] lg:top-[25px] left-[25px] lg:left-[35px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px] whitespace-nowrap">
+                  Vast Gallery
+                </div>
+                <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-[7px] lg:top-[9px] right-[7px] lg:left-[215px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
+                  <img
+                    className="w-8 lg:w-10 h-8 lg:h-10"
+                    alt="Arrow forward"
+                    src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-2.svg"
+                  />
+                </div>
+              </div>
+              <img
+                className="w-full h-[140px] lg:h-[182px] object-cover"
+                alt="Gallery preview"
+                src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-2.png"
+              />
+            </div>
+
+            <div className="absolute w-60 lg:w-[292px] h-[110px] lg:h-[139px] top-[350px] lg:top-[523px] left-0 hidden lg:block">
+              <div className="relative w-full h-full bg-white rounded-[20px] border border-solid border-black p-4 lg:p-6">
+                <div className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px]">
+                  Revenue
+                </div>
+                <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-2 lg:top-2.5 right-2 lg:left-[207px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
+                  <img
+                    className="w-8 lg:w-10 h-8 lg:h-10"
+                    alt="Arrow forward"
+                    src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward.svg"
+                  />
+                </div>
+                <div className="mt-2 [font-family:'Golos_Text',Helvetica] font-medium text-black text-3xl lg:text-5xl tracking-[-2px] lg:tracking-[-2.88px] leading-[1.1] lg:leading-[50.6px]">
+                  150K+
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HeroSection;
+

--- a/src/components/LocationDropdown.tsx
+++ b/src/components/LocationDropdown.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { MapPin } from 'lucide-react';
+import './Dropdown.css';
+
+interface LocationDropdownProps {
+  onSelect: (location: string) => void;
+  onClose: () => void;
+  isMobile?: boolean;
+}
+
+const locations = [
+  'Toronto, Canada',
+  'Vancouver, Canada',
+  'Montreal, Canada',
+  'Calgary, Canada',
+  'Ottawa, Canada'
+];
+
+const LocationDropdown: React.FC<LocationDropdownProps> = ({ onSelect, onClose, isMobile = false }) => {
+  const handleSelect = (loc: string) => {
+    onSelect(loc);
+  };
+
+  const content = (
+    <ul className="dropdown-list">
+      {locations.map((loc) => (
+        <li key={loc} className="dropdown-item" onClick={() => handleSelect(loc)}>
+          <MapPin className="w-4 h-4 mr-2 text-[#4CAF87]" />
+          {loc}
+        </li>
+      ))}
+    </ul>
+  );
+
+  return isMobile ? (
+    <div className="mobile-modal">
+      <button className="modal-close" onClick={onClose}>
+        &times;
+      </button>
+      {content}
+    </div>
+  ) : (
+    <div className="dropdown">{content}</div>
+  );
+};
+
+export default LocationDropdown;

--- a/src/components/PriceDropdown.tsx
+++ b/src/components/PriceDropdown.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import './Dropdown.css';
+
+interface PriceDropdownProps {
+  onSelect: (price: string) => void;
+  onClose: () => void;
+  isMobile?: boolean;
+}
+
+const prices = [
+  'Any price',
+  '$500 - $1,000',
+  '$1,000 - $2,000',
+  '$2,000 - $3,000',
+  '$3,000+'
+];
+
+const PriceDropdown: React.FC<PriceDropdownProps> = ({ onSelect, onClose, isMobile = false }) => {
+  const handleSelect = (p: string) => {
+    onSelect(p);
+  };
+
+  const content = (
+    <ul className="dropdown-list">
+      {prices.map((p) => (
+        <li key={p} className="dropdown-item" onClick={() => handleSelect(p)}>
+          {p}
+        </li>
+      ))}
+    </ul>
+  );
+
+  return isMobile ? (
+    <div className="mobile-modal">
+      <button className="modal-close" onClick={onClose}>
+        &times;
+      </button>
+      {content}
+    </div>
+  ) : (
+    <div className="dropdown">{content}</div>
+  );
+};
+
+export default PriceDropdown;

--- a/src/components/SearchBar.css
+++ b/src/components/SearchBar.css
@@ -1,0 +1,36 @@
+.search-bar-container {
+  @apply w-full flex items-center bg-white border-2 border-[#569b6f]/30 rounded-full shadow-md transition-all duration-300 ease-in-out overflow-hidden;
+}
+.search-bar-container.desktop { @apply h-16; }
+.search-bar-container.desktop.scrolled { @apply h-12; }
+.search-bar-container.mobile { @apply h-12; }
+.search-bar-container.mobile.scrolled { @apply h-10; }
+
+.section {
+  @apply flex-1 px-4 cursor-pointer border-r border-[#569b6f]/20 overflow-hidden;
+}
+.section:last-child { @apply border-r-0; }
+.label {
+  @apply block text-[#569b6f] font-semibold text-sm;
+}
+.value {
+  @apply block text-gray-700 text-sm;
+}
+
+.search-button {
+  @apply ml-2 bg-[#4CAF87] text-white rounded-full flex items-center justify-center h-10 w-10 transition-all duration-300 ease-in-out whitespace-nowrap;
+}
+.search-button.expanded {
+  @apply px-4 w-auto;
+}
+.search-button:hover { @apply bg-[#4d8a63]; }
+
+.search-bar-overlay {
+  @apply fixed inset-0 bg-black/30 opacity-0 transition-opacity duration-300 pointer-events-none z-40;
+}
+.search-bar-overlay.active {
+  @apply opacity-100 pointer-events-auto;
+}
+
+.no-scrollbar::-webkit-scrollbar { display: none; }
+.no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import { Button } from './ui/button';
-import { Input } from './ui/input';
+import LocationDropdown from './LocationDropdown';
+import PriceDropdown from './PriceDropdown';
+import GuestsDropdown from './GuestsDropdown';
+import './SearchBar.css';
 
 interface SearchBarProps {
   isScrolled: boolean;
@@ -8,230 +11,106 @@ interface SearchBarProps {
   className?: string;
 }
 
-export const SearchBar: React.FC<SearchBarProps> = ({ 
-  isScrolled, 
-  isMobile = false, 
-  className = '' 
+const SearchBar: React.FC<SearchBarProps> = ({
+  isScrolled,
+  isMobile = false,
+  className = ''
 }) => {
-  const [searchData, setSearchData] = useState({
-    location: '',
-    price: '',
-    guests: 1
-  });
-  const [activeField, setActiveField] = useState<string | null>(null);
+  const [location, setLocation] = useState('');
+  const [price, setPrice] = useState('');
+  const [guests, setGuests] = useState(1);
+  const [active, setActive] = useState<null | 'location' | 'price' | 'guests'>(null);
+
+  const open = (field: 'location' | 'price' | 'guests') => setActive(field);
+  const close = () => setActive(null);
 
   const handleSearch = () => {
-    console.log('Search triggered:', searchData);
-    // Add search logic here
+    console.log('Searching', { location, price, guests });
+    close();
   };
 
-  const handleInputChange = (field: string, value: string | number) => {
-    setSearchData(prev => ({
-      ...prev,
-      [field]: value
-    }));
-  };
+  const activeSearch = location !== '' || price !== '' || guests > 1;
 
-  const formatGuestText = (count: number) => {
-    if (count === 1) return '1 guest';
-    return `${count} guests`;
-  };
-
-  // Mobile layout
-  if (isMobile) {
-    return (
-      <div className={`w-full transition-all duration-300 ease-in-out ${className}`}>
-        <div className={`bg-white rounded-full border-2 border-[#569b6f]/30 shadow-md hover:shadow-lg transition-all duration-300 ease-in-out ${isScrolled ? 'h-10' : 'h-12'}`}>
-          <div className="flex items-center h-full px-3">
-            {/* Compact Location Input */}
-            <div className="flex-1 mr-2">
-              <Input
-                type="text"
-                placeholder="Where to?"
-                value={searchData.location}
-                onChange={(e) => handleInputChange('location', e.target.value)}
-                className={`border-none bg-transparent p-0 h-auto [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}
-                aria-label="Search location"
-              />
-            </div>
-
-            {/* Guest Counter */}
-            <div className="flex items-center space-x-1 mr-2">
-              <button
-                onClick={() => handleInputChange('guests', Math.max(1, searchData.guests - 1))}
-                className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                disabled={searchData.guests <= 1}
-                aria-label="Decrease guest count"
-              >
-                <span className="text-[#569b6f] text-xs">−</span>
-              </button>
-              <span className={`[font-family:'Golos_Text',Helvetica] font-medium text-[#569b6f] min-w-[15px] text-center transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                {searchData.guests}
-              </span>
-              <button
-                onClick={() => handleInputChange('guests', Math.min(16, searchData.guests + 1))}
-                className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                aria-label="Increase guest count"
-              >
-                <span className="text-[#569b6f] text-xs">+</span>
-              </button>
-            </div>
-
-            {/* Search Button */}
-            <Button
-              onClick={handleSearch}
-              className={`rounded-full bg-[#569b6f] hover:bg-[#4d8a63] text-white [font-family:'Golos_Text',Helvetica] font-bold shadow-md hover:shadow-lg transition-all duration-300 ease-in-out p-0 ${isScrolled ? 'h-6 w-6' : 'h-8 w-8'}`}
-              aria-label="Search properties"
-            >
-              <svg className={`transition-all duration-300 ease-in-out ${isScrolled ? 'w-3 h-3' : 'w-4 h-4'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-            </Button>
-          </div>
-        </div>
-
-        {/* Mobile Price Input Below */}
-        {!isScrolled && (
-          <div className="mt-2">
-            <Input
-              type="text"
-              placeholder="Price range (e.g., $1000-$2000)"
-              value={searchData.price}
-              onChange={(e) => handleInputChange('price', e.target.value)}
-              className="w-full bg-white border-2 border-[#569b6f]/30 rounded-full px-4 py-2 [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 text-sm"
-              aria-label="Price range"
-            />
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // Desktop layout
   return (
-    <div className={`relative transition-all duration-300 ease-in-out ${className}`}>
-      <div className={`bg-white rounded-full border-2 border-[#569b6f]/30 shadow-md hover:shadow-lg transition-all duration-300 ease-in-out ${isScrolled ? 'h-12' : 'h-16'}`}>
-        <div className="flex items-center h-full">
-          {/* Location Input */}
-          <div className="flex-1 px-4 md:px-6 border-r border-[#569b6f]/20">
-            <div className="flex flex-col justify-center h-full">
-              <label className={`text-[#569b6f] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                Where
-              </label>
-              <Input
-                type="text"
-                placeholder="Search destinations"
-                value={searchData.location}
-                onChange={(e) => handleInputChange('location', e.target.value)}
-                onFocus={() => setActiveField('location')}
-                onBlur={() => setActiveField(null)}
-                className={`border-none bg-transparent p-0 h-auto [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}
-                aria-label="Search location"
-              />
-            </div>
-          </div>
+    <div className={`relative search-bar ${className}`}>
+      {/* Overlay */}
+      <div
+        className={`search-bar-overlay ${active ? 'active' : ''}`}
+        onClick={close}
+      />
 
-          {/* Price Input */}
-          <div className="flex-1 px-4 md:px-6 border-r border-[#569b6f]/20">
-            <div className="flex flex-col justify-center h-full">
-              <label className={`text-[#569b6f] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                Price Range
-              </label>
-              <Input
-                type="text"
-                placeholder="Any price"
-                value={searchData.price}
-                onChange={(e) => handleInputChange('price', e.target.value)}
-                onFocus={() => setActiveField('price')}
-                onBlur={() => setActiveField(null)}
-                className={`border-none bg-transparent p-0 h-auto [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}
-                aria-label="Price range"
-              />
-            </div>
-          </div>
-
-          {/* Guests Input */}
-          <div className="flex-1 px-4 md:px-6">
-            <div className="flex flex-col justify-center h-full">
-              <label className={`text-[#569b6f] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                Guests
-              </label>
-              <div className="flex items-center space-x-2">
-                <button
-                  onClick={() => handleInputChange('guests', Math.max(1, searchData.guests - 1))}
-                  className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                  disabled={searchData.guests <= 1}
-                  aria-label="Decrease guest count"
-                >
-                  <span className="text-[#569b6f] text-sm">−</span>
-                </button>
-                <span className={`[font-family:'Golos_Text',Helvetica] font-medium text-gray-700 min-w-[20px] text-center transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}>
-                  {searchData.guests}
-                </span>
-                <button
-                  onClick={() => handleInputChange('guests', Math.min(16, searchData.guests + 1))}
-                  className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                  aria-label="Increase guest count"
-                >
-                  <span className="text-[#569b6f] text-sm">+</span>
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Search Button */}
-          <div className="pr-2">
-            <Button
-              onClick={handleSearch}
-              className={`rounded-full bg-[#569b6f] hover:bg-[#4d8a63] text-white [font-family:'Golos_Text',Helvetica] font-bold shadow-md hover:shadow-lg transition-all duration-300 ease-in-out p-0 ${isScrolled ? 'h-8 w-8' : 'h-12 w-12'}`}
-              aria-label="Search properties"
-            >
-              <svg className={`transition-all duration-300 ease-in-out ${isScrolled ? 'w-4 h-4' : 'w-5 h-5'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-            </Button>
-          </div>
+      {/* Bar */}
+      <div
+        className={`search-bar-container ${isScrolled ? 'scrolled' : ''} ${isMobile ? 'mobile' : 'desktop'}`}
+      >
+        <div className="section" onClick={() => open('location')}>
+          <span className="label">Where</span>
+          <span className="value">{location || 'Add location'}</span>
         </div>
+        <div className="section" onClick={() => open('price')}>
+          <span className="label">Price</span>
+          <span className="value">{price || 'Any price'}</span>
+        </div>
+        <div className="section" onClick={() => open('guests')}>
+          <span className="label">Guests</span>
+          <span className="value">{guests} {guests === 1 ? 'guest' : 'guests'}</span>
+        </div>
+        <Button
+          onClick={handleSearch}
+          className={`search-button ${activeSearch ? 'expanded' : ''}`}
+          aria-label="Search properties"
+        >
+          {activeSearch ? 'Search' : (
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+          )}
+        </Button>
       </div>
 
-      {/* Desktop Dropdown Suggestions (shown when focused) */}
-      {activeField === 'location' && !isScrolled && (
-        <div className="absolute top-full left-0 mt-2 w-80 bg-white rounded-2xl shadow-xl border border-[#569b6f]/20 p-4 z-50">
-          <div className="space-y-2">
-            <div className="text-xs font-semibold text-[#569b6f] uppercase tracking-wide [font-family:'Golos_Text',Helvetica]">Popular destinations</div>
-            {['Toronto, ON', 'Vancouver, BC', 'Montreal, QC', 'Calgary, AB'].map((city) => (
-              <button
-                key={city}
-                className="block w-full text-left px-3 py-2 rounded-lg hover:bg-[#569b6f]/5 text-sm [font-family:'Golos_Text',Helvetica] transition-colors"
-                onClick={() => {
-                  handleInputChange('location', city);
-                  setActiveField(null);
-                }}
-              >
-                {city}
-              </button>
-            ))}
-          </div>
+      {/* Dropdowns */}
+      {active === 'location' && (
+        <div className="absolute left-0 top-full">
+          <LocationDropdown
+            isMobile={isMobile}
+            onSelect={(loc) => {
+              setLocation(loc);
+              setActive('price');
+            }}
+            onClose={close}
+          />
         </div>
       )}
-
-      {activeField === 'price' && !isScrolled && (
-        <div className="absolute top-full left-1/3 mt-2 w-64 bg-white rounded-2xl shadow-xl border border-[#569b6f]/20 p-4 z-50">
-          <div className="space-y-2">
-            <div className="text-xs font-semibold text-[#569b6f] uppercase tracking-wide [font-family:'Golos_Text',Helvetica]">Price ranges</div>
-            {['$500 - $1000', '$1000 - $1500', '$1500 - $2000', '$2000+'].map((range) => (
-              <button
-                key={range}
-                className="block w-full text-left px-3 py-2 rounded-lg hover:bg-[#569b6f]/5 text-sm [font-family:'Golos_Text',Helvetica] transition-colors"
-                onClick={() => {
-                  handleInputChange('price', range);
-                  setActiveField(null);
-                }}
-              >
-                {range}
-              </button>
-            ))}
-          </div>
+      {active === 'price' && (
+        <div className="absolute left-1/3 top-full">
+          <PriceDropdown
+            isMobile={isMobile}
+            onSelect={(p) => {
+              setPrice(p);
+              setActive('guests');
+            }}
+            onClose={close}
+          />
+        </div>
+      )}
+      {active === 'guests' && (
+        <div className="absolute left-2/3 top-full">
+          <GuestsDropdown
+            isMobile={isMobile}
+            value={guests}
+            onChange={(count) => setGuests(count)}
+            onClose={close}
+          />
         </div>
       )}
     </div>

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -4,7 +4,7 @@ import { PropertyCarousels } from './PropertyCarousels';
 
 export const ServicesSection: React.FC = () => {
   return (
-    <section className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[url(https://c.animaapp.com/mdww1mm3xpw4UO/img/rectangle-56.svg)] bg-cover bg-center bg-no-repeat">
+    <section id="services" className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[url(https://c.animaapp.com/mdww1mm3xpw4UO/img/rectangle-56.svg)] bg-cover bg-center bg-no-repeat">
       <div className="container py-8 md:py-10 lg:py-12">
         {/* Section Header */}
         <div className="flex items-center mb-6 md:mb-8">

--- a/src/screens/House/House.tsx
+++ b/src/screens/House/House.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { Badge } from "../../components/ui/badge";
-import { Button } from "../../components/ui/button";
-import { Card, CardContent } from "../../components/ui/card";
-import { Input } from "../../components/ui/input";
 import { ServicesSection } from "../../components/ServicesSection";
 import Header from "../../components/Header";
+import HeroSection from "../../components/HeroSection";
 
 export const House = (): JSX.Element => {
   return (
@@ -14,86 +12,7 @@ export const House = (): JSX.Element => {
         <Header />
 
         {/* Hero Section */}
-        <section className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[#fff7eb]">
-          <div className="container h-full">
-            <div className="flex flex-col lg:flex-row items-center lg:items-start h-full">
-              {/* Hero Content */}
-              <div className="flex-1 pt-16 md:pt-24 lg:pt-40 text-center lg:text-left">
-                <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-4xl md:text-6xl lg:text-8xl tracking-[-2px] md:tracking-[-4px] lg:tracking-[-5.76px] leading-tight md:leading-[1.1] lg:leading-[84.3px] mb-6 md:mb-8 lg:mb-10">
-                  Welcome To Your <br />
-                  Canadian Dream
-                </h1>
-                <p className="w-full max-w-[400px] md:max-w-[500px] lg:max-w-[522px] mx-auto lg:mx-0 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-lg md:text-2xl lg:text-[32px] tracking-[-1px] md:tracking-[-1.5px] lg:tracking-[-1.92px] leading-relaxed md:leading-[1.2] lg:leading-[28.1px] mb-8 md:mb-10 lg:mb-12">
-                  At the frontier of the living lavish lifestyle in Canada
-                </p>
-                
-                <Button className="relative h-[55px] md:h-[65px] lg:h-[72px] w-[280px] md:w-[300px] lg:w-[328px] bg-[#569b6f] rounded-[30px] md:rounded-[35px] lg:rounded-[43px] [font-family:'Golos_Text',Helvetica] font-medium text-white text-lg md:text-xl lg:text-2xl tracking-[-1px] md:tracking-[-1.2px] lg:tracking-[-1.44px] hover:bg-[#4d8a63] transition-colors overflow-hidden">
-                  <span className="relative z-10">Explore Our Service</span>
-                  <div className="absolute w-[45px] md:w-[55px] lg:w-[62px] h-[45px] md:h-[55px] lg:h-[62px] top-[5px] right-[5px] bg-white rounded-[25px] md:rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
-                    <img
-                      className="w-[20px] md:w-[25px] lg:w-[30px] h-[20px] md:h-[25px] lg:h-[30px]"
-                      alt="Arrow forward"
-                      src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-1.svg"
-                    />
-                  </div>
-                </Button>
-              </div>
-
-              {/* Hero Image Section - Hidden on mobile, visible on large screens */}
-              <div className="relative w-full max-w-[600px] lg:max-w-[722px] h-[400px] md:h-[600px] lg:h-[864px] mt-8 lg:mt-[109px] hidden md:block">
-                <div className="absolute w-[70%] lg:w-[573px] h-full lg:h-[864px] top-0 left-[15%] lg:left-[113px] bg-[#ffc3698c] rounded-[200px_200px_0px_0px] lg:rounded-[300px_300px_0px_0px]" />
-                <img
-                  className="absolute w-[60%] lg:w-[504px] h-[85%] lg:h-[792px] top-4 lg:top-9 left-[20%] lg:left-[146px] object-cover"
-                  alt="Luxury home"
-                  src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group.png"
-                />
-
-                {/* Floating Cards - Only visible on large screens */}
-                <Card className="absolute w-60 lg:w-72 h-[200px] lg:h-[257px] top-[100px] lg:top-[135px] right-0 lg:left-[434px] hidden lg:block">
-                  <CardContent className="p-0">
-                    <div className="relative w-full h-[60px] lg:h-[75px] bg-white rounded-[20px_20px_0px_0px] border border-solid border-black">
-                      <div className="absolute top-[20px] lg:top-[25px] left-[25px] lg:left-[35px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px] whitespace-nowrap">
-                        Vast Gallery
-                      </div>
-                      <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-[7px] lg:top-[9px] right-[7px] lg:left-[215px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
-                        <img
-                          className="w-8 lg:w-10 h-8 lg:h-10"
-                          alt="Arrow forward"
-                          src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-2.svg"
-                        />
-                      </div>
-                    </div>
-                    <img
-                      className="w-full h-[140px] lg:h-[182px] object-cover"
-                      alt="Gallery preview"
-                      src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-2.png"
-                    />
-                  </CardContent>
-                </Card>
-
-                <Card className="absolute w-60 lg:w-[292px] h-[110px] lg:h-[139px] top-[350px] lg:top-[523px] left-0 hidden lg:block">
-                  <CardContent className="p-0">
-                    <div className="relative w-full h-full bg-white rounded-[20px] border border-solid border-black p-4 lg:p-6">
-                      <div className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px]">
-                        Revenue
-                      </div>
-                      <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-2 lg:top-2.5 right-2 lg:left-[207px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
-                        <img
-                          className="w-8 lg:w-10 h-8 lg:h-10"
-                          alt="Arrow forward"
-                          src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward.svg"
-                        />
-                      </div>
-                      <div className="mt-2 [font-family:'Golos_Text',Helvetica] font-medium text-black text-3xl lg:text-5xl tracking-[-2px] lg:tracking-[-2.88px] leading-[1.1] lg:leading-[50.6px]">
-                        150K+
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            </div>
-          </div>
-        </section>
+        <HeroSection />
 
         {/* About Us Section */}
         <section className="w-full bg-white">


### PR DESCRIPTION
## Summary
- Make header permanently sticky with scroll-based shrinking and overflow hidden
- Rebuild search bar with guided Where/Price/Guests dropdowns and full-screen overlay
- Add hero section component with smooth scroll and updated "Explore Our Listings" button

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d98b6875c8326bd65671f73527918