### PR TITLE
Implement sticky header with guided search dropdowns

### DIFF
--- a/src/components/Dropdown.css
+++ b/src/components/Dropdown.css
@@ -1,0 +1,76 @@
+.dropdown-desktop {
+  position: absolute;
+  top: 100%;
+  margin-top: 0.5rem;
+  width: 16rem;
+  background: #fff;
+  border: 1px solid rgba(76, 175, 135, 0.2);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 50;
+}
+
+.dropdown-desktop.open {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.dropdown-item {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  font-family: 'Golos_Text', Helvetica, sans-serif;
+  transition: background-color 0.2s ease;
+}
+
+.dropdown-item:hover {
+  background-color: rgba(76, 175, 135, 0.1);
+}
+
+.dropdown-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: flex-end;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.modal-mobile {
+  width: 100%;
+  background: #fff;
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+  padding: 1rem;
+  max-height: 80vh;
+  overflow-y: auto;
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+}
+
+.modal-mobile.open {
+  transform: translateY(0);
+}
+
+.guest-btn {
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid rgba(76, 175, 135, 0.3);
+  border-radius: 9999px;
+  color: #4CAF87;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.guest-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.guest-btn:not(:disabled):hover {
+  background-color: rgba(76, 175, 135, 0.05);
+  border-color: #4CAF87;
+}
+

--- a/src/components/GuestsDropdown.tsx
+++ b/src/components/GuestsDropdown.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { Button } from './ui/button';
+import './Dropdown.css';
+
+interface GuestsDropdownProps {
+  guests: number;
+  onSelect: (guests: number) => void;
+  onClose: () => void;
+  isMobile?: boolean;
+  className?: string;
+}
+
+const GuestsDropdown: React.FC<GuestsDropdownProps> = ({
+  guests,
+  onSelect,
+  onClose,
+  isMobile = false,
+  className = ''
+}) => {
+  const [count, setCount] = useState(guests);
+
+  const change = (delta: number) => {
+    setCount((prev) => Math.max(1, prev + delta));
+  };
+
+  const apply = () => {
+    onSelect(count);
+    onClose();
+  };
+
+  const controls = (
+    <div className="flex flex-col items-center space-y-4">
+      <div className="flex items-center space-x-4">
+        <button
+          className="guest-btn"
+          onClick={() => change(-1)}
+          disabled={count <= 1}
+        >
+          -
+        </button>
+        <span className="text-lg" aria-live="polite">
+          {count}
+        </span>
+        <button className="guest-btn" onClick={() => change(1)}>
+          +
+        </button>
+      </div>
+      <Button
+        onClick={apply}
+        className="bg-[#4CAF87] hover:bg-[#3b9b73] text-white rounded-full px-4 py-1 transition"
+      >
+        Apply
+      </Button>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="dropdown-modal">
+        <div className="modal-mobile open">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-[#4CAF87] font-semibold">Guests</h2>
+            <button className="text-2xl" onClick={onClose}>
+              &times;
+            </button>
+          </div>
+          {controls}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`dropdown-desktop open ${className}`}>{controls}</div>
+  );
+};
+
+export default GuestsDropdown;
+

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,12 @@
+.header-sticky {
+  overflow: hidden;
+}
+
+.header-sticky::-webkit-scrollbar {
+  display: none;
+}
+
+.search-overlay {
+  transition: opacity 0.3s ease;
+}
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from './ui/button';
 import SearchBar from './SearchBar';
+import './Header.css';
 
 export const Header: React.FC = () => {
   const [isScrolled, setIsScrolled] = useState(false);
+  const [searchActive, setSearchActive] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -16,10 +18,13 @@ export const Header: React.FC = () => {
   }, []);
 
   return (
-    <header className={`sticky top-0 z-50 w-full bg-[#FFF7EB] border-b border-[#569b6f]/20 transition-all duration-300 ease-in-out ${isScrolled ? 'py-2 shadow-lg' : 'py-4 md:py-6'}`}>
-      <div className="container mx-auto px-4 md:px-6 lg:px-8">
-        {/* Desktop Layout - Logo and Search Bar Side by Side */}
-        <div className="hidden md:flex items-center justify-between">
+    <>
+      <header
+        className={`header-sticky fixed top-0 left-0 z-50 w-full bg-[#FFF7EB] border-b border-[#569b6f]/20 transition-all duration-300 ease-in-out origin-top transform ${isScrolled ? 'py-2 shadow-lg scale-95' : 'py-4 md:py-6 scale-100'}`}
+      >
+        <div className="container mx-auto px-4 md:px-6 lg:px-8">
+          {/* Desktop Layout - Logo and Search Bar Side by Side */}
+          <div className="hidden md:flex items-center justify-between">
           {/* Left Side - Logo and Search Bar */}
           <div className="flex items-center flex-1 max-w-4xl">
             {/* Logo */}
@@ -41,7 +46,7 @@ export const Header: React.FC = () => {
 
             {/* Search Bar */}
             <div className="flex-1 max-w-2xl">
-              <SearchBar isScrolled={isScrolled} />
+              <SearchBar isScrolled={isScrolled} onOverlayChange={setSearchActive} />
             </div>
           </div>
 
@@ -89,11 +94,15 @@ export const Header: React.FC = () => {
 
           {/* Search Bar Row */}
           <div className="w-full">
-            <SearchBar isScrolled={isScrolled} isMobile={true} />
+            <SearchBar isScrolled={isScrolled} isMobile={true} onOverlayChange={setSearchActive} />
           </div>
         </div>
       </div>
-    </header>
+      </header>
+      <div
+        className={`search-overlay fixed inset-0 bg-black/40 ${searchActive ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+      />
+    </>
   );
 };
 

--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -1,0 +1,4 @@
+.hero-btn:hover {
+  opacity: 0.95;
+}
+

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Button } from './ui/button';
+import { Card, CardContent } from './ui/card';
+import './HeroSection.css';
+
+const HeroSection: React.FC = () => {
+  const scrollToServices = () => {
+    document.getElementById('services')?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <section className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[#fff7eb]">
+      <div className="container h-full">
+        <div className="flex flex-col lg:flex-row items-center lg:items-start h-full">
+          {/* Hero Content */}
+          <div className="flex-1 pt-16 md:pt-24 lg:pt-40 text-center lg:text-left">
+            <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-4xl md:text-6xl lg:text-8xl tracking-[-2px] md:tracking-[-4px] lg:tracking-[-5.76px] leading-tight md:leading-[1.1] lg:leading-[84.3px] mb-6 md:mb-8 lg:mb-10">
+              Welcome To Your <br />
+              Canadian Dream
+            </h1>
+            <p className="w-full max-w-[400px] md:max-w-[500px] lg:max-w-[522px] mx-auto lg:mx-0 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-lg md:text-2xl lg:text-[32px] tracking-[-1px] md:tracking-[-1.5px] lg:tracking-[-1.92px] leading-relaxed md:leading-[1.2] lg:leading-[28.1px] mb-8 md:mb-10 lg:mb-12">
+              At the frontier of the living lavish lifestyle in Canada
+            </p>
+
+            <Button
+              onClick={scrollToServices}
+              className="hero-btn relative h-[55px] md:h-[65px] lg:h-[72px] w-[280px] md:w-[300px] lg:w-[328px] bg-[#4CAF87] rounded-[30px] md:rounded-[35px] lg:rounded-[43px] [font-family:'Golos_Text',Helvetica] font-medium text-white text-lg md:text-xl lg:text-2xl tracking-[-1px] md:tracking-[-1.2px] lg:tracking-[-1.44px] hover:bg-[#3b9b73] transition-colors overflow-hidden pr-16 md:pr-20 lg:pr-24">
+              <span className="relative z-10">Explore Our Listings</span>
+              <div className="absolute w-[45px] md:w-[55px] lg:w-[62px] h-[45px] md:h-[55px] lg:h-[62px] top-[5px] right-[5px] bg-white rounded-[25px] md:rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
+                <img
+                  className="w-[20px] md:w-[25px] lg:w-[30px] h-[20px] md:h-[25px] lg:h-[30px]"
+                  alt="Arrow forward"
+                  src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-1.svg"
+                />
+              </div>
+            </Button>
+          </div>
+
+          {/* Hero Image Section - Hidden on mobile, visible on large screens */}
+          <div className="relative w-full max-w-[600px] lg:max-w-[722px] h-[400px] md:h-[600px] lg:h-[864px] mt-8 lg:mt-[109px] hidden md:block">
+            <div className="absolute w-[70%] lg:w-[573px] h-full lg:h-[864px] top-0 left-[15%] lg:left-[113px] bg-[#ffc3698c] rounded-[200px_200px_0px_0px] lg:rounded-[300px_300px_0px_0px]" />
+            <img
+              className="absolute w-[60%] lg:w-[504px] h-[85%] lg:h-[792px] top-4 lg:top-9 left-[20%] lg:left-[146px] object-cover"
+              alt="Luxury home"
+              src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group.png"
+            />
+
+            {/* Floating Cards - Only visible on large screens */}
+            <Card className="absolute w-60 lg:w-72 h-[200px] lg:h-[257px] top-[100px] lg:top-[135px] right-0 lg:left-[434px] hidden lg:block">
+              <CardContent className="p-0">
+                <div className="relative w-full h-[60px] lg:h-[75px] bg-white rounded-[20px_20px_0px_0px] border border-solid border-black">
+                <div className="absolute top-[20px] lg:top-[25px] left-[25px] lg:left-[35px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px] whitespace-nowrap">
+                    Vast Gallery
+                  </div>
+                  <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-[7px] lg:top-[9px] right-[7px] lg:left-[215px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
+                    <img
+                      className="w-8 lg:w-10 h-8 lg:h-10"
+                      alt="Arrow forward"
+                      src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-2.svg"
+                    />
+                  </div>
+                </div>
+                <img
+                  className="w-full h-[140px] lg:h-[182px] object-cover"
+                  alt="Gallery preview"
+                  src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-2.png"
+                />
+              </CardContent>
+            </Card>
+
+            <Card className="absolute w-60 lg:w-[292px] h-[110px] lg:h-[139px] top-[350px] lg:top-[523px] left-0 hidden lg:block">
+              <CardContent className="p-0">
+                <div className="relative w-full h-full bg-white rounded-[20px] border border-solid border-black p-4 lg:p-6">
+                  <div className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px]">
+                    Revenue
+                  </div>
+                  <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-2 lg:top-2.5 right-2 lg:left-[207px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
+                    <img
+                      className="w-8 lg:w-10 h-8 lg:h-10"
+                      alt="Arrow forward"
+                      src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward.svg"
+                    />
+                  </div>
+                  <div className="mt-2 [font-family:'Golos_Text',Helvetica] font-medium text-black text-3xl lg:text-5xl tracking-[-2px] lg:tracking-[-2.88px] leading-[1.1] lg:leading-[50.6px]">
+                    150K+
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HeroSection;
+

--- a/src/components/LocationDropdown.tsx
+++ b/src/components/LocationDropdown.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import './Dropdown.css';
+
+interface LocationDropdownProps {
+  onSelect: (location: string) => void;
+  onClose: () => void;
+  isMobile?: boolean;
+  className?: string;
+}
+
+const locations = [
+  'Toronto, Canada',
+  'Vancouver, Canada',
+  'Montreal, Canada',
+  'Calgary, Canada',
+  'Ottawa, Canada'
+];
+
+const LocationDropdown: React.FC<LocationDropdownProps> = ({
+  onSelect,
+  onClose,
+  isMobile = false,
+  className = ''
+}) => {
+  const content = (
+    <ul className="space-y-2">
+      {locations.map((loc) => (
+        <li key={loc}>
+          <button
+            className="dropdown-item flex items-center w-full"
+            onClick={() => {
+              onSelect(loc);
+              onClose();
+            }}
+          >
+            <svg
+              className="w-4 h-4 mr-2 text-[#4CAF87]"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 11c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 22s8-4.5 8-11c0-4.418-3.582-8-8-8S4 6.582 4 11c0 6.5 8 11 8 11z"
+              />
+            </svg>
+            {loc}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="dropdown-modal">
+        <div className="modal-mobile open">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-[#4CAF87] font-semibold">Where</h2>
+            <button className="text-2xl" onClick={onClose}>
+              &times;
+            </button>
+          </div>
+          {content}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`dropdown-desktop open ${className}`}>
+      {content}
+    </div>
+  );
+};
+
+export default LocationDropdown;
+

--- a/src/components/PriceDropdown.tsx
+++ b/src/components/PriceDropdown.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import './Dropdown.css';
+
+interface PriceDropdownProps {
+  onSelect: (price: string) => void;
+  onClose: () => void;
+  isMobile?: boolean;
+  className?: string;
+}
+
+const prices = [
+  'Any price',
+  '$500 - $1,000',
+  '$1,000 - $2,000',
+  '$2,000 - $3,000',
+  '$3,000+'
+];
+
+const PriceDropdown: React.FC<PriceDropdownProps> = ({
+  onSelect,
+  onClose,
+  isMobile = false,
+  className = ''
+}) => {
+  const content = (
+    <ul className="space-y-2">
+      {prices.map((price) => (
+        <li key={price}>
+          <button
+            className="dropdown-item w-full text-left"
+            onClick={() => {
+              onSelect(price);
+              onClose();
+            }}
+          >
+            {price}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="dropdown-modal">
+        <div className="modal-mobile open">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-[#4CAF87] font-semibold">Price</h2>
+            <button className="text-2xl" onClick={onClose}>
+              &times;
+            </button>
+          </div>
+          {content}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`dropdown-desktop open ${className}`}>
+      {content}
+    </div>
+  );
+};
+
+export default PriceDropdown;
+

--- a/src/components/SearchBar.css
+++ b/src/components/SearchBar.css
@@ -1,0 +1,4 @@
+.search-button:hover {
+  opacity: 0.9;
+}
+

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,241 +1,157 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from './ui/button';
-import { Input } from './ui/input';
+import LocationDropdown from './LocationDropdown';
+import PriceDropdown from './PriceDropdown';
+import GuestsDropdown from './GuestsDropdown';
+import './SearchBar.css';
 
 interface SearchBarProps {
   isScrolled: boolean;
   isMobile?: boolean;
   className?: string;
+  onOverlayChange?: (active: boolean) => void;
 }
 
-export const SearchBar: React.FC<SearchBarProps> = ({ 
-  isScrolled, 
-  isMobile = false, 
-  className = '' 
+export const SearchBar: React.FC<SearchBarProps> = ({
+  isScrolled,
+  isMobile = false,
+  className = '',
+  onOverlayChange
 }) => {
-  const [searchData, setSearchData] = useState({
-    location: '',
-    price: '',
-    guests: 1
-  });
-  const [activeField, setActiveField] = useState<string | null>(null);
+  const [location, setLocation] = useState('');
+  const [price, setPrice] = useState('');
+  const [guests, setGuests] = useState(1);
+  const [active, setActive] = useState<null | 'location' | 'price' | 'guests'>(null);
+
+  useEffect(() => {
+    onOverlayChange?.(active !== null);
+  }, [active, onOverlayChange]);
+
+  const formatGuests = (n: number) => (n === 1 ? '1 guest' : `${n} guests`);
+
+  const handleLocationSelect = (loc: string) => {
+    setLocation(loc);
+    setActive('price');
+  };
+
+  const handlePriceSelect = (value: string) => {
+    setPrice(value);
+    setActive('guests');
+  };
+
+  const handleGuestsSelect = (count: number) => {
+    setGuests(count);
+    setActive(null);
+  };
+
+  const isActiveSearch = Boolean(active || location || price || guests !== 1);
 
   const handleSearch = () => {
-    console.log('Search triggered:', searchData);
-    // Add search logic here
+    console.log('Search', { location, price, guests });
+    setActive(null);
   };
 
-  const handleInputChange = (field: string, value: string | number) => {
-    setSearchData(prev => ({
-      ...prev,
-      [field]: value
-    }));
-  };
-
-  const formatGuestText = (count: number) => {
-    if (count === 1) return '1 guest';
-    return `${count} guests`;
-  };
-
-  // Mobile layout
-  if (isMobile) {
-    return (
-      <div className={`w-full transition-all duration-300 ease-in-out ${className}`}>
-        <div className={`bg-white rounded-full border-2 border-[#569b6f]/30 shadow-md hover:shadow-lg transition-all duration-300 ease-in-out ${isScrolled ? 'h-10' : 'h-12'}`}>
-          <div className="flex items-center h-full px-3">
-            {/* Compact Location Input */}
-            <div className="flex-1 mr-2">
-              <Input
-                type="text"
-                placeholder="Where to?"
-                value={searchData.location}
-                onChange={(e) => handleInputChange('location', e.target.value)}
-                className={`border-none bg-transparent p-0 h-auto [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}
-                aria-label="Search location"
-              />
-            </div>
-
-            {/* Guest Counter */}
-            <div className="flex items-center space-x-1 mr-2">
-              <button
-                onClick={() => handleInputChange('guests', Math.max(1, searchData.guests - 1))}
-                className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                disabled={searchData.guests <= 1}
-                aria-label="Decrease guest count"
-              >
-                <span className="text-[#569b6f] text-xs">−</span>
-              </button>
-              <span className={`[font-family:'Golos_Text',Helvetica] font-medium text-[#569b6f] min-w-[15px] text-center transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                {searchData.guests}
-              </span>
-              <button
-                onClick={() => handleInputChange('guests', Math.min(16, searchData.guests + 1))}
-                className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                aria-label="Increase guest count"
-              >
-                <span className="text-[#569b6f] text-xs">+</span>
-              </button>
-            </div>
-
-            {/* Search Button */}
-            <Button
-              onClick={handleSearch}
-              className={`rounded-full bg-[#569b6f] hover:bg-[#4d8a63] text-white [font-family:'Golos_Text',Helvetica] font-bold shadow-md hover:shadow-lg transition-all duration-300 ease-in-out p-0 ${isScrolled ? 'h-6 w-6' : 'h-8 w-8'}`}
-              aria-label="Search properties"
-            >
-              <svg className={`transition-all duration-300 ease-in-out ${isScrolled ? 'w-3 h-3' : 'w-4 h-4'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-            </Button>
-          </div>
-        </div>
-
-        {/* Mobile Price Input Below */}
-        {!isScrolled && (
-          <div className="mt-2">
-            <Input
-              type="text"
-              placeholder="Price range (e.g., $1000-$2000)"
-              value={searchData.price}
-              onChange={(e) => handleInputChange('price', e.target.value)}
-              className="w-full bg-white border-2 border-[#569b6f]/30 rounded-full px-4 py-2 [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 text-sm"
-              aria-label="Price range"
-            />
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // Desktop layout
   return (
     <div className={`relative transition-all duration-300 ease-in-out ${className}`}>
-      <div className={`bg-white rounded-full border-2 border-[#569b6f]/30 shadow-md hover:shadow-lg transition-all duration-300 ease-in-out ${isScrolled ? 'h-12' : 'h-16'}`}>
-        <div className="flex items-center h-full">
-          {/* Location Input */}
-          <div className="flex-1 px-4 md:px-6 border-r border-[#569b6f]/20">
-            <div className="flex flex-col justify-center h-full">
-              <label className={`text-[#569b6f] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                Where
-              </label>
-              <Input
-                type="text"
-                placeholder="Search destinations"
-                value={searchData.location}
-                onChange={(e) => handleInputChange('location', e.target.value)}
-                onFocus={() => setActiveField('location')}
-                onBlur={() => setActiveField(null)}
-                className={`border-none bg-transparent p-0 h-auto [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}
-                aria-label="Search location"
-              />
-            </div>
-          </div>
+      <div
+        className={`bg-white rounded-full border-2 border-[#4CAF87]/30 shadow-md hover:shadow-lg transition-all duration-300 ease-in-out ${isScrolled ? 'h-12' : 'h-16'}`}
+      >
+        <div className="flex items-center h-full overflow-hidden">
+          <button
+            className="flex-1 px-4 md:px-6 text-left border-r border-[#4CAF87]/20 focus:outline-none"
+            onClick={() => setActive('location')}
+          >
+            <span
+              className={`block text-[#4CAF87] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ${isScrolled ? 'text-xs' : 'text-sm'}`}
+            >
+              Where
+            </span>
+            <span
+              className={`block [font-family:'Golos_Text',Helvetica] text-gray-700 transition-all duration-300 ${isScrolled ? 'text-sm' : 'text-base'}`}
+            >
+              {location || 'Search destinations'}
+            </span>
+          </button>
 
-          {/* Price Input */}
-          <div className="flex-1 px-4 md:px-6 border-r border-[#569b6f]/20">
-            <div className="flex flex-col justify-center h-full">
-              <label className={`text-[#569b6f] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                Price Range
-              </label>
-              <Input
-                type="text"
-                placeholder="Any price"
-                value={searchData.price}
-                onChange={(e) => handleInputChange('price', e.target.value)}
-                onFocus={() => setActiveField('price')}
-                onBlur={() => setActiveField(null)}
-                className={`border-none bg-transparent p-0 h-auto [font-family:'Golos_Text',Helvetica] text-gray-700 placeholder:text-[#9f9f9f] focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}
-                aria-label="Price range"
-              />
-            </div>
-          </div>
+          <button
+            className="flex-1 px-4 md:px-6 text-left border-r border-[#4CAF87]/20 focus:outline-none"
+            onClick={() => setActive('price')}
+          >
+            <span
+              className={`block text-[#4CAF87] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ${isScrolled ? 'text-xs' : 'text-sm'}`}
+            >
+              Price
+            </span>
+            <span
+              className={`block [font-family:'Golos_Text',Helvetica] text-gray-700 transition-all duration-300 ${isScrolled ? 'text-sm' : 'text-base'}`}
+            >
+              {price || 'Any price'}
+            </span>
+          </button>
 
-          {/* Guests Input */}
-          <div className="flex-1 px-4 md:px-6">
-            <div className="flex flex-col justify-center h-full">
-              <label className={`text-[#569b6f] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ease-in-out ${isScrolled ? 'text-xs' : 'text-sm'}`}>
-                Guests
-              </label>
-              <div className="flex items-center space-x-2">
-                <button
-                  onClick={() => handleInputChange('guests', Math.max(1, searchData.guests - 1))}
-                  className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                  disabled={searchData.guests <= 1}
-                  aria-label="Decrease guest count"
-                >
-                  <span className="text-[#569b6f] text-sm">−</span>
-                </button>
-                <span className={`[font-family:'Golos_Text',Helvetica] font-medium text-gray-700 min-w-[20px] text-center transition-all duration-300 ease-in-out ${isScrolled ? 'text-sm' : 'text-base'}`}>
-                  {searchData.guests}
-                </span>
-                <button
-                  onClick={() => handleInputChange('guests', Math.min(16, searchData.guests + 1))}
-                  className={`rounded-full border border-[#569b6f]/30 flex items-center justify-center hover:border-[#569b6f] hover:bg-[#569b6f]/5 transition-all duration-300 ease-in-out ${isScrolled ? 'w-5 h-5' : 'w-6 h-6'}`}
-                  aria-label="Increase guest count"
-                >
-                  <span className="text-[#569b6f] text-sm">+</span>
-                </button>
-              </div>
-            </div>
-          </div>
+          <button
+            className="flex-1 px-4 md:px-6 text-left focus:outline-none"
+            onClick={() => setActive('guests')}
+          >
+            <span
+              className={`block text-[#4CAF87] font-semibold [font-family:'Golos_Text',Helvetica] transition-all duration-300 ${isScrolled ? 'text-xs' : 'text-sm'}`}
+            >
+              Guests
+            </span>
+            <span
+              className={`block [font-family:'Golos_Text',Helvetica] text-gray-700 transition-all duration-300 ${isScrolled ? 'text-sm' : 'text-base'}`}
+            >
+              {formatGuests(guests)}
+            </span>
+          </button>
 
-          {/* Search Button */}
           <div className="pr-2">
             <Button
               onClick={handleSearch}
-              className={`rounded-full bg-[#569b6f] hover:bg-[#4d8a63] text-white [font-family:'Golos_Text',Helvetica] font-bold shadow-md hover:shadow-lg transition-all duration-300 ease-in-out p-0 ${isScrolled ? 'h-8 w-8' : 'h-12 w-12'}`}
-              aria-label="Search properties"
+              className={`search-button rounded-full bg-[#4CAF87] text-white [font-family:'Golos_Text',Helvetica] font-bold shadow-md transition-all duration-300 ${isActiveSearch ? 'px-4 h-10' : 'h-10 w-10'} ${isScrolled ? 'text-sm' : 'text-base'}`}
             >
-              <svg className={`transition-all duration-300 ease-in-out ${isScrolled ? 'w-4 h-4' : 'w-5 h-5'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
+              {isActiveSearch ? (
+                'Search'
+              ) : (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+              )}
             </Button>
           </div>
         </div>
       </div>
 
-      {/* Desktop Dropdown Suggestions (shown when focused) */}
-      {activeField === 'location' && !isScrolled && (
-        <div className="absolute top-full left-0 mt-2 w-80 bg-white rounded-2xl shadow-xl border border-[#569b6f]/20 p-4 z-50">
-          <div className="space-y-2">
-            <div className="text-xs font-semibold text-[#569b6f] uppercase tracking-wide [font-family:'Golos_Text',Helvetica]">Popular destinations</div>
-            {['Toronto, ON', 'Vancouver, BC', 'Montreal, QC', 'Calgary, AB'].map((city) => (
-              <button
-                key={city}
-                className="block w-full text-left px-3 py-2 rounded-lg hover:bg-[#569b6f]/5 text-sm [font-family:'Golos_Text',Helvetica] transition-colors"
-                onClick={() => {
-                  handleInputChange('location', city);
-                  setActiveField(null);
-                }}
-              >
-                {city}
-              </button>
-            ))}
-          </div>
-        </div>
+      {active === 'location' && (
+        <LocationDropdown
+          isMobile={isMobile}
+          className="left-0"
+          onSelect={handleLocationSelect}
+          onClose={() => setActive(null)}
+        />
       )}
 
-      {activeField === 'price' && !isScrolled && (
-        <div className="absolute top-full left-1/3 mt-2 w-64 bg-white rounded-2xl shadow-xl border border-[#569b6f]/20 p-4 z-50">
-          <div className="space-y-2">
-            <div className="text-xs font-semibold text-[#569b6f] uppercase tracking-wide [font-family:'Golos_Text',Helvetica]">Price ranges</div>
-            {['$500 - $1000', '$1000 - $1500', '$1500 - $2000', '$2000+'].map((range) => (
-              <button
-                key={range}
-                className="block w-full text-left px-3 py-2 rounded-lg hover:bg-[#569b6f]/5 text-sm [font-family:'Golos_Text',Helvetica] transition-colors"
-                onClick={() => {
-                  handleInputChange('price', range);
-                  setActiveField(null);
-                }}
-              >
-                {range}
-              </button>
-            ))}
-          </div>
-        </div>
+      {active === 'price' && (
+        <PriceDropdown
+          isMobile={isMobile}
+          className="left-1/3"
+          onSelect={handlePriceSelect}
+          onClose={() => setActive(null)}
+        />
+      )}
+
+      {active === 'guests' && (
+        <GuestsDropdown
+          isMobile={isMobile}
+          className="right-0"
+          guests={guests}
+          onSelect={handleGuestsSelect}
+          onClose={() => setActive(null)}
+        />
       )}
     </div>
   );
 };
 
 export default SearchBar;
+

--- a/src/screens/House/House.tsx
+++ b/src/screens/House/House.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { Badge } from "../../components/ui/badge";
-import { Button } from "../../components/ui/button";
-import { Card, CardContent } from "../../components/ui/card";
-import { Input } from "../../components/ui/input";
 import { ServicesSection } from "../../components/ServicesSection";
 import Header from "../../components/Header";
+import HeroSection from "../../components/HeroSection";
 
 export const House = (): JSX.Element => {
   return (
@@ -14,86 +12,7 @@ export const House = (): JSX.Element => {
         <Header />
 
         {/* Hero Section */}
-        <section className="w-full min-h-[600px] md:min-h-[800px] lg:min-h-[973px] bg-[#fff7eb]">
-          <div className="container h-full">
-            <div className="flex flex-col lg:flex-row items-center lg:items-start h-full">
-              {/* Hero Content */}
-              <div className="flex-1 pt-16 md:pt-24 lg:pt-40 text-center lg:text-left">
-                <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-4xl md:text-6xl lg:text-8xl tracking-[-2px] md:tracking-[-4px] lg:tracking-[-5.76px] leading-tight md:leading-[1.1] lg:leading-[84.3px] mb-6 md:mb-8 lg:mb-10">
-                  Welcome To Your <br />
-                  Canadian Dream
-                </h1>
-                <p className="w-full max-w-[400px] md:max-w-[500px] lg:max-w-[522px] mx-auto lg:mx-0 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-lg md:text-2xl lg:text-[32px] tracking-[-1px] md:tracking-[-1.5px] lg:tracking-[-1.92px] leading-relaxed md:leading-[1.2] lg:leading-[28.1px] mb-8 md:mb-10 lg:mb-12">
-                  At the frontier of the living lavish lifestyle in Canada
-                </p>
-                
-                <Button className="relative h-[55px] md:h-[65px] lg:h-[72px] w-[280px] md:w-[300px] lg:w-[328px] bg-[#569b6f] rounded-[30px] md:rounded-[35px] lg:rounded-[43px] [font-family:'Golos_Text',Helvetica] font-medium text-white text-lg md:text-xl lg:text-2xl tracking-[-1px] md:tracking-[-1.2px] lg:tracking-[-1.44px] hover:bg-[#4d8a63] transition-colors overflow-hidden">
-                  <span className="relative z-10">Explore Our Service</span>
-                  <div className="absolute w-[45px] md:w-[55px] lg:w-[62px] h-[45px] md:h-[55px] lg:h-[62px] top-[5px] right-[5px] bg-white rounded-[25px] md:rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
-                    <img
-                      className="w-[20px] md:w-[25px] lg:w-[30px] h-[20px] md:h-[25px] lg:h-[30px]"
-                      alt="Arrow forward"
-                      src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-1.svg"
-                    />
-                  </div>
-                </Button>
-              </div>
-
-              {/* Hero Image Section - Hidden on mobile, visible on large screens */}
-              <div className="relative w-full max-w-[600px] lg:max-w-[722px] h-[400px] md:h-[600px] lg:h-[864px] mt-8 lg:mt-[109px] hidden md:block">
-                <div className="absolute w-[70%] lg:w-[573px] h-full lg:h-[864px] top-0 left-[15%] lg:left-[113px] bg-[#ffc3698c] rounded-[200px_200px_0px_0px] lg:rounded-[300px_300px_0px_0px]" />
-                <img
-                  className="absolute w-[60%] lg:w-[504px] h-[85%] lg:h-[792px] top-4 lg:top-9 left-[20%] lg:left-[146px] object-cover"
-                  alt="Luxury home"
-                  src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group.png"
-                />
-
-                {/* Floating Cards - Only visible on large screens */}
-                <Card className="absolute w-60 lg:w-72 h-[200px] lg:h-[257px] top-[100px] lg:top-[135px] right-0 lg:left-[434px] hidden lg:block">
-                  <CardContent className="p-0">
-                    <div className="relative w-full h-[60px] lg:h-[75px] bg-white rounded-[20px_20px_0px_0px] border border-solid border-black">
-                      <div className="absolute top-[20px] lg:top-[25px] left-[25px] lg:left-[35px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px] whitespace-nowrap">
-                        Vast Gallery
-                      </div>
-                      <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-[7px] lg:top-[9px] right-[7px] lg:left-[215px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
-                        <img
-                          className="w-8 lg:w-10 h-8 lg:h-10"
-                          alt="Arrow forward"
-                          src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward-2.svg"
-                        />
-                      </div>
-                    </div>
-                    <img
-                      className="w-full h-[140px] lg:h-[182px] object-cover"
-                      alt="Gallery preview"
-                      src="https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-2.png"
-                    />
-                  </CardContent>
-                </Card>
-
-                <Card className="absolute w-60 lg:w-[292px] h-[110px] lg:h-[139px] top-[350px] lg:top-[523px] left-0 hidden lg:block">
-                  <CardContent className="p-0">
-                    <div className="relative w-full h-full bg-white rounded-[20px] border border-solid border-black p-4 lg:p-6">
-                      <div className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-[20px] lg:text-[28px] tracking-[-1px] lg:tracking-[-1.68px] leading-[1.2] lg:leading-[29.5px]">
-                        Revenue
-                      </div>
-                      <div className="w-[45px] lg:w-[58px] h-[45px] lg:h-[58px] top-2 lg:top-2.5 right-2 lg:left-[207px] bg-black absolute rounded-[30px] lg:rounded-[40px] flex items-center justify-center">
-                        <img
-                          className="w-8 lg:w-10 h-8 lg:h-10"
-                          alt="Arrow forward"
-                          src="https://c.animaapp.com/mdww1mm3xpw4UO/img/arrow-forward.svg"
-                        />
-                      </div>
-                      <div className="mt-2 [font-family:'Golos_Text',Helvetica] font-medium text-black text-3xl lg:text-5xl tracking-[-2px] lg:tracking-[-2.88px] leading-[1.1] lg:leading-[50.6px]">
-                        150K+
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            </div>
-          </div>
-        </section>
+        <HeroSection />
 
         {/* About Us Section */}
         <section className="w-full bg-white">


### PR DESCRIPTION
## Summary
- Keep header fixed at top with scroll-based shrink and overlay when search is active
- Rebuild search bar with sequential location/price/guest dropdowns and new search button
- Add hero section component with smooth scroll and updated call to action

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d98b6875c8326bd65671f73527918