### PR TITLE
feat: improve header and search interactions

### DIFF
--- a/src/components/Dropdown.css
+++ b/src/components/Dropdown.css
@@ -14,6 +14,17 @@
   z-index: 50;
 }
 
+.dropdown-desktop,
+.modal-mobile {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.dropdown-desktop::-webkit-scrollbar,
+.modal-mobile::-webkit-scrollbar {
+  display: none;
+}
+
 .dropdown-desktop.open {
   opacity: 1;
   transform: translateY(0);

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,5 +1,7 @@
 .header-sticky {
   overflow: hidden;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }
 
 .header-sticky::-webkit-scrollbar {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,8 +20,13 @@ export const Header: React.FC = () => {
   return (
     <>
       <header
-        className={`header-sticky fixed top-0 left-0 z-50 w-full bg-[#FFF7EB] border-b border-[#569b6f]/20 transition-all duration-300 ease-in-out origin-top transform ${isScrolled ? 'py-2 shadow-lg scale-95' : 'py-4 md:py-6 scale-100'}`}
+        className={`header-sticky fixed top-0 left-0 z-50 w-full bg-[#FFF7EB] border-b border-[#569b6f]/20 transition-all duration-300 ease-in-out ${isScrolled ? 'py-2 shadow-lg' : 'py-4 md:py-6'}`}
       >
+        <div
+          className={`transform origin-top transition-all duration-300 ease-in-out ${
+            isScrolled ? 'scale-95' : 'scale-100'
+          }`}
+        >
         <div className="container mx-auto px-4 md:px-6 lg:px-8">
           {/* Desktop Layout - Logo and Search Bar Side by Side */}
           <div className="hidden md:flex items-center justify-between">
@@ -97,6 +102,7 @@ export const Header: React.FC = () => {
             <SearchBar isScrolled={isScrolled} isMobile={true} onOverlayChange={setSearchActive} />
           </div>
         </div>
+      </div>
       </div>
       </header>
       <div

--- a/src/components/LocationDropdown.tsx
+++ b/src/components/LocationDropdown.tsx
@@ -28,10 +28,7 @@ const LocationDropdown: React.FC<LocationDropdownProps> = ({
         <li key={loc}>
           <button
             className="dropdown-item flex items-center w-full"
-            onClick={() => {
-              onSelect(loc);
-              onClose();
-            }}
+            onClick={() => onSelect(loc)}
           >
             <svg
               className="w-4 h-4 mr-2 text-[#4CAF87]"

--- a/src/components/PriceDropdown.tsx
+++ b/src/components/PriceDropdown.tsx
@@ -28,10 +28,7 @@ const PriceDropdown: React.FC<PriceDropdownProps> = ({
         <li key={price}>
           <button
             className="dropdown-item w-full text-left"
-            onClick={() => {
-              onSelect(price);
-              onClose();
-            }}
+            onClick={() => onSelect(price)}
           >
             {price}
           </button>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -111,10 +111,25 @@ export const SearchBar: React.FC<SearchBarProps> = ({
               className={`search-button rounded-full bg-[#4CAF87] text-white [font-family:'Golos_Text',Helvetica] font-bold shadow-md transition-all duration-300 ${isActiveSearch ? 'px-4 h-10' : 'h-10 w-10'} ${isScrolled ? 'text-sm' : 'text-base'}`}
             >
               {isActiveSearch ? (
-                'Search'
+                <span className="flex items-center space-x-2">
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                    />
+                  </svg>
+                  <span>Search</span>
+                </span>
               ) : (
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                  />
                 </svg>
               )}
             </Button>


### PR DESCRIPTION
## Summary
- ensure sticky header stays full width while scaling smoothly
- refine search bar with guided dropdown flow and search button
- remove scrollbars and enhance dropdown/modal styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db29b6bb083269866998ac6d501c1