### PR TITLE
Fix full-width sticky header and portal dropdowns

### DIFF
--- a/src/components/Dropdown.css
+++ b/src/components/Dropdown.css
@@ -1,7 +1,6 @@
 .dropdown-desktop {
   position: absolute;
-  top: 100%;
-  margin-top: 0.5rem;
+  /* Coordinates provided inline when rendered through portals */
   width: 16rem;
   background: #fff;
   border: 1px solid rgba(76, 175, 135, 0.2);
@@ -11,7 +10,7 @@
   opacity: 0;
   transform: translateY(-8px);
   transition: opacity 0.2s ease, transform 0.2s ease;
-  z-index: 50;
+  z-index: 1000;
   overflow: hidden;
 }
 
@@ -35,7 +34,7 @@
 .dropdown-modal {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 1000;
   display: flex;
   align-items: flex-end;
   background: rgba(0, 0, 0, 0.3);
@@ -80,4 +79,3 @@
   background-color: rgba(76, 175, 135, 0.05);
   border-color: #4CAF87;
 }
-

--- a/src/components/GuestsDropdown.tsx
+++ b/src/components/GuestsDropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Button } from './ui/button';
 import './Dropdown.css';
 
@@ -8,6 +9,7 @@ interface GuestsDropdownProps {
   onClose: () => void;
   isMobile?: boolean;
   className?: string;
+  anchorRect?: DOMRect | null;
 }
 
 const GuestsDropdown: React.FC<GuestsDropdownProps> = ({
@@ -15,7 +17,8 @@ const GuestsDropdown: React.FC<GuestsDropdownProps> = ({
   onSelect,
   onClose,
   isMobile = false,
-  className = ''
+  className = '',
+  anchorRect = null,
 }) => {
   const [count, setCount] = useState(guests);
 
@@ -59,7 +62,7 @@ const GuestsDropdown: React.FC<GuestsDropdownProps> = ({
   );
 
   if (isMobile) {
-    return (
+    return createPortal(
       <div className="dropdown-modal" onClick={onClose}>
         <div className="modal-mobile open" onClick={(e) => e.stopPropagation()}>
           <div className="flex justify-between items-center mb-4">
@@ -70,12 +73,29 @@ const GuestsDropdown: React.FC<GuestsDropdownProps> = ({
           </div>
           {controls}
         </div>
-      </div>
+      </div>,
+      document.body
     );
   }
 
-  return (
-    <div className={`dropdown-desktop open ${className}`}>{controls}</div>
+  if (!anchorRect) return null;
+
+  const width = 256; // 16rem
+  let left = anchorRect.left;
+  if (left + width > window.innerWidth) {
+    left = window.innerWidth - width - 16;
+  }
+
+  const style: React.CSSProperties = {
+    top: anchorRect.bottom + window.scrollY + 8,
+    left,
+  };
+
+  return createPortal(
+    <div className={`dropdown-desktop open ${className}`} style={style}>
+      {controls}
+    </div>,
+    document.body
   );
 };
 

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,5 +1,7 @@
 .header-sticky {
-  overflow-x: hidden;
+  /* Prevent any scrollbars from appearing on the sticky header */
+  overflow: hidden;
+  width: 100vw;
 }
 
 .search-overlay {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,7 @@ export const Header: React.FC = () => {
 
   return (
     <>
-      <header className="header-sticky fixed top-0 left-0 right-0 z-50 w-full bg-[#FFF7EB] border-b border-[#569b6f]/20">
+      <header className="header-sticky fixed top-0 left-0 z-50 w-screen bg-[#FFF7EB] border-b border-[#569b6f]/20">
         <div className={`w-full transition-all duration-300 ease-in-out ${isScrolled ? 'py-2 shadow-lg' : 'py-4 md:py-6'}`}>
           <div className="max-w-7xl mx-auto px-4 md:px-6 lg:px-8">
             {/* Desktop Layout - Logo and Search Bar Side by Side */}

--- a/src/components/LocationDropdown.tsx
+++ b/src/components/LocationDropdown.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import './Dropdown.css';
 
 interface LocationDropdownProps {
@@ -6,6 +7,7 @@ interface LocationDropdownProps {
   onClose: () => void;
   isMobile?: boolean;
   className?: string;
+  anchorRect?: DOMRect | null;
 }
 
 const locations = [
@@ -20,7 +22,8 @@ const LocationDropdown: React.FC<LocationDropdownProps> = ({
   onSelect,
   onClose,
   isMobile = false,
-  className = ''
+  className = '',
+  anchorRect = null,
 }) => {
   const handleSelect = (location: string) => {
     onSelect(location);
@@ -63,7 +66,7 @@ const LocationDropdown: React.FC<LocationDropdownProps> = ({
   );
 
   if (isMobile) {
-    return (
+    return createPortal(
       <div className="dropdown-modal" onClick={onClose}>
         <div className="modal-mobile open" onClick={(e) => e.stopPropagation()}>
           <div className="flex justify-between items-center mb-4">
@@ -74,14 +77,23 @@ const LocationDropdown: React.FC<LocationDropdownProps> = ({
           </div>
           {content}
         </div>
-      </div>
+      </div>,
+      document.body
     );
   }
 
-  return (
-    <div className={`dropdown-desktop open ${className}`}>
+  if (!anchorRect) return null;
+
+  const style: React.CSSProperties = {
+    top: anchorRect.bottom + window.scrollY + 8,
+    left: anchorRect.left,
+  };
+
+  return createPortal(
+    <div className={`dropdown-desktop open ${className}`} style={style}>
       {content}
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/src/components/PriceDropdown.tsx
+++ b/src/components/PriceDropdown.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import './Dropdown.css';
 
 interface PriceDropdownProps {
@@ -6,6 +7,7 @@ interface PriceDropdownProps {
   onClose: () => void;
   isMobile?: boolean;
   className?: string;
+  anchorRect?: DOMRect | null;
 }
 
 const prices = [
@@ -20,7 +22,8 @@ const PriceDropdown: React.FC<PriceDropdownProps> = ({
   onSelect,
   onClose,
   isMobile = false,
-  className = ''
+  className = '',
+  anchorRect = null,
 }) => {
   const handleSelect = (price: string) => {
     onSelect(price);
@@ -44,7 +47,7 @@ const PriceDropdown: React.FC<PriceDropdownProps> = ({
   );
 
   if (isMobile) {
-    return (
+    return createPortal(
       <div className="dropdown-modal" onClick={onClose}>
         <div className="modal-mobile open" onClick={(e) => e.stopPropagation()}>
           <div className="flex justify-between items-center mb-4">
@@ -55,14 +58,29 @@ const PriceDropdown: React.FC<PriceDropdownProps> = ({
           </div>
           {content}
         </div>
-      </div>
+      </div>,
+      document.body
     );
   }
 
-  return (
-    <div className={`dropdown-desktop open ${className}`}>
+  if (!anchorRect) return null;
+
+  const width = 256; // 16rem
+  let left = anchorRect.left;
+  if (left + width > window.innerWidth) {
+    left = window.innerWidth - width - 16; // keep some margin
+  }
+
+  const style: React.CSSProperties = {
+    top: anchorRect.bottom + window.scrollY + 8,
+    left,
+  };
+
+  return createPortal(
+    <div className={`dropdown-desktop open ${className}`} style={style}>
       {content}
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Button } from './ui/button';
 import LocationDropdown from './LocationDropdown';
 import PriceDropdown from './PriceDropdown';
@@ -22,6 +22,10 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   const [price, setPrice] = useState('');
   const [guests, setGuests] = useState(1);
   const [active, setActive] = useState<null | 'location' | 'price' | 'guests'>(null);
+
+  const locationRef = useRef<HTMLButtonElement>(null);
+  const priceRef = useRef<HTMLButtonElement>(null);
+  const guestsRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     onOverlayChange?.(active !== null);
@@ -64,6 +68,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
       >
         <div className="flex items-center h-full overflow-hidden">
           <button
+            ref={locationRef}
             className="flex-1 px-4 md:px-6 text-left border-r border-[#4CAF87]/20 focus:outline-none"
             onClick={() => setActive('location')}
           >
@@ -80,6 +85,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
           </button>
 
           <button
+            ref={priceRef}
             className="flex-1 px-4 md:px-6 text-left border-r border-[#4CAF87]/20 focus:outline-none"
             onClick={() => setActive('price')}
           >
@@ -96,6 +102,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
           </button>
 
           <button
+            ref={guestsRef}
             className="flex-1 px-4 md:px-6 text-left focus:outline-none"
             onClick={() => setActive('guests')}
           >
@@ -128,7 +135,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
       {active === 'location' && (
         <LocationDropdown
           isMobile={isMobile}
-          className="left-0"
+          anchorRect={locationRef.current?.getBoundingClientRect() || null}
           onSelect={handleLocationSelect}
           onClose={handleClickOutside}
         />
@@ -137,7 +144,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
       {active === 'price' && (
         <PriceDropdown
           isMobile={isMobile}
-          className="left-1/3"
+          anchorRect={priceRef.current?.getBoundingClientRect() || null}
           onSelect={handlePriceSelect}
           onClose={handleClickOutside}
         />
@@ -146,7 +153,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
       {active === 'guests' && (
         <GuestsDropdown
           isMobile={isMobile}
-          className="right-0"
+          anchorRect={guestsRef.current?.getBoundingClientRect() || null}
           guests={guests}
           onSelect={handleGuestsSelect}
           onClose={handleClickOutside}


### PR DESCRIPTION
## Summary
- Ensure sticky header spans entire viewport without scrollbars
- Render search dropdowns in portals and align them to their fields
- Raise dropdown z-index so overlays sit above hero content

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db94ffe88832681f15a1ea7a8187f