### PR TITLE
feat: add listings page with map and search filters

### DIFF
--- a/.screen-graph.json
+++ b/.screen-graph.json
@@ -1,4 +1,38 @@
 {
-  "nodes": [],
-  "edges": []
+  "nodes": [
+    {
+      "id": "src/screens/House/House.tsx",
+      "label": "House",
+      "routes": [
+        "/"
+      ],
+      "dataModelId": "2060:120",
+      "isRoot": true
+    },
+    {
+      "id": "src/pages/listings.tsx",
+      "label": "listings",
+      "routes": [
+        "/listings"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "id": "src/pages/listings.tsx:33:4-to-src/pages/listings.tsx",
+      "source": "src/pages/listings.tsx",
+      "target": "src/pages/listings.tsx",
+      "data": {
+        "viaRoute": "/listings",
+        "trigger": {
+          "element": "navigate('/listings')",
+          "line": 33,
+          "endLine": 33,
+          "column": 4,
+          "endColumn": 25,
+          "sourceFile": "src/pages/listings.tsx"
+        }
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,14 @@
       "dependencies": {
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
+        "@types/leaflet": "^1.9.20",
         "class-variance-authority": "^0.7.0",
         "clsx": "2.1.1",
+        "leaflet": "^1.9.4",
         "lucide-react": "^0.453.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-leaflet": "^4.2.1",
         "react-router-dom": "^6.8.1",
         "tailwind-merge": "2.5.4",
         "tailwind-scrollbar-hide": "latest",
@@ -1428,6 +1431,17 @@
         }
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1768,6 +1782,21 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.20",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
+      "integrity": "sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2468,6 +2497,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -2898,6 +2933,20 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,20 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@radix-ui/react-separator": "^1.1.0",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@types/leaflet": "^1.9.20",
+    "class-variance-authority": "^0.7.0",
     "clsx": "2.1.1",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.453.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.8.1",
     "tailwind-merge": "2.5.4",
-    "tailwindcss-animate": "1.0.7",
-    "@radix-ui/react-slot": "^1.1.0",
-    "class-variance-authority": "^0.7.0",
-    "@radix-ui/react-separator": "^1.1.0",
-    "tailwind-scrollbar-hide": "latest"
+    "tailwind-scrollbar-hide": "latest",
+    "tailwindcss-animate": "1.0.7"
   },
   "devDependencies": {
     "@animaapp/vite-plugin-screen-graph": "^0.1.5",

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Listing } from '../hooks/useListingsData';
+
+interface Props {
+  listing: Listing;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+export const ListingCard: React.FC<Props> = ({ listing, selected, onClick }) => {
+  return (
+    <div
+      id={`listing-${listing.id}`}
+      onClick={onClick}
+      className={`cursor-pointer mb-4 border rounded-lg overflow-hidden shadow-md bg-white transition-colors duration-300 ${
+        selected ? 'border-[#4CAF87]' : 'border-gray-200'
+      }`}
+    >
+      <img src={listing.image} alt={listing.title} className="w-full h-48 object-cover" />
+      <div className="p-4">
+        <h3 className="text-lg font-bold text-black mb-1">{listing.title}</h3>
+        <p className="text-sm text-gray-600">{listing.location}</p>
+        <p className="text-[#4CAF87] font-semibold mt-2">${listing.price} / month</p>
+        <p className="text-sm text-gray-600">{listing.guests} guest{listing.guests > 1 ? 's' : ''}</p>
+      </div>
+    </div>
+  );
+};
+
+export default ListingCard;

--- a/src/components/MapPanel.tsx
+++ b/src/components/MapPanel.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useRef } from 'react';
+import { MapContainer, TileLayer, Marker } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import '../styles/Listings.css';
+import { Listing } from '../hooks/useListingsData';
+
+interface Props {
+  listings: Listing[];
+  selectedId?: number | null;
+  onSelect?: (id: number) => void;
+  locationParam?: string | null;
+}
+
+const MapPanel: React.FC<Props> = ({ listings, selectedId, onSelect, locationParam }) => {
+  const mapRef = useRef<L.Map | null>(null);
+
+  useEffect(() => {
+    if (!mapRef.current || listings.length === 0) return;
+    if (locationParam) {
+      const match = listings.find((l) =>
+        l.location.toLowerCase().includes(locationParam.toLowerCase())
+      );
+      if (match) {
+        mapRef.current.setView([match.coordinates.lat, match.coordinates.lng], 12);
+        return;
+      }
+    }
+    const bounds = L.latLngBounds(
+      listings.map((l) => [l.coordinates.lat, l.coordinates.lng] as [number, number])
+    );
+    mapRef.current.fitBounds(bounds, { padding: [30, 30] });
+  }, [listings, locationParam]);
+
+  useEffect(() => {
+    if (!mapRef.current) return;
+    const selected = listings.find((l) => l.id === selectedId);
+    if (selected) {
+      mapRef.current.setView([selected.coordinates.lat, selected.coordinates.lng], 12);
+    }
+  }, [selectedId, listings]);
+
+  const createIcon = (id: number) =>
+    L.divIcon({
+      className: `listing-marker${id === selectedId ? ' selected' : ''}`,
+      html: '<div></div>',
+    });
+
+  return (
+    <MapContainer
+      style={{ height: '100%', width: '100%' }}
+      zoom={4}
+      center={[56, -106]}
+      whenCreated={(map) => {
+        mapRef.current = map;
+      }}
+    >
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+      {listings.map((l) => (
+        <Marker
+          key={l.id}
+          position={[l.coordinates.lat, l.coordinates.lng]}
+          icon={createIcon(l.id)}
+          eventHandlers={{
+            click: () => onSelect?.(l.id),
+          }}
+        />
+      ))}
+    </MapContainer>
+  );
+};
+
+export default MapPanel;

--- a/src/data/mockListings.ts
+++ b/src/data/mockListings.ts
@@ -1,0 +1,38 @@
+export const mockListings = [
+  {
+    id: 1,
+    title: "Modern Condo in Downtown Toronto",
+    location: "Toronto, Canada",
+    price: 1800,
+    guests: 2,
+    image: "/images/listing1.jpg",
+    coordinates: { lat: 43.6532, lng: -79.3832 }
+  },
+  {
+    id: 2,
+    title: "Cozy Apartment in Vancouver",
+    location: "Vancouver, Canada",
+    price: 1500,
+    guests: 4,
+    image: "/images/listing2.jpg",
+    coordinates: { lat: 49.2827, lng: -123.1207 }
+  },
+  {
+    id: 3,
+    title: "Luxury Home in Montreal",
+    location: "Montreal, Canada",
+    price: 2500,
+    guests: 5,
+    image: "/images/listing3.jpg",
+    coordinates: { lat: 45.5017, lng: -73.5673 }
+  },
+  {
+    id: 4,
+    title: "Calgary Family House",
+    location: "Calgary, Canada",
+    price: 1300,
+    guests: 3,
+    image: "/images/listing4.jpg",
+    coordinates: { lat: 51.0447, lng: -114.0719 }
+  }
+];

--- a/src/hooks/useListingsData.ts
+++ b/src/hooks/useListingsData.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { mockListings } from '../data/mockListings';
+
+export interface Listing {
+  id: number;
+  title: string;
+  location: string;
+  price: number;
+  guests: number;
+  image: string;
+  coordinates: { lat: number; lng: number };
+}
+
+export const useListingsData = () => {
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const locationHook = useLocation();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/listings');
+        if (res.ok) {
+          const data = await res.json();
+          if (Array.isArray(data) && data.length) {
+            setListings(data);
+            setLoading(false);
+            return;
+          }
+        }
+      } catch (err) {
+        // ignore and use mock data
+      }
+      setListings(mockListings);
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  const params = new URLSearchParams(locationHook.search);
+  let filtered = [...listings];
+
+  const locationParam = params.get('location');
+  const priceParam = params.get('price');
+  const guestsParam = parseInt(params.get('guests') || '1', 10);
+  const sortParam = params.get('sort');
+
+  if (locationParam) {
+    filtered = filtered.filter((l) =>
+      l.location.toLowerCase().includes(locationParam.toLowerCase())
+    );
+  }
+
+  if (priceParam) {
+    const [minStr, maxStr] = priceParam.split('-');
+    const min = parseInt(minStr, 10);
+    const max = parseInt(maxStr, 10);
+    filtered = filtered.filter((l) =>
+      l.price >= min && (isNaN(max) ? true : l.price <= max)
+    );
+  }
+
+  if (guestsParam) {
+    filtered = filtered.filter((l) => l.guests >= guestsParam);
+  }
+
+  if (sortParam === 'asc') {
+    filtered.sort((a, b) => a.price - b.price);
+  } else if (sortParam === 'desc') {
+    filtered.sort((a, b) => b.price - a.price);
+  }
+
+  return { listings: filtered, loading };
+};
+
+export default useListingsData;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,16 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { House } from "./screens/House";
+import ListingsPage from './pages/listings';
 
 createRoot(document.getElementById("app") as HTMLElement).render(
   <StrictMode>
-    <House />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<House />} />
+        <Route path="/listings" element={<ListingsPage />} />
+      </Routes>
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/src/pages/listings.tsx
+++ b/src/pages/listings.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import Header from '../components/Header';
+import ListingCard from '../components/ListingCard';
+import MapPanel from '../components/MapPanel';
+import useListingsData from '../hooks/useListingsData';
+import '../styles/Listings.css';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const ITEMS_PER_PAGE = 12;
+
+const ListingsPage: React.FC = () => {
+  const { listings } = useListingsData();
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [page, setPage] = useState(1);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const params = new URLSearchParams(location.search);
+  const sortParam = params.get('sort') || '';
+  const locationParam = params.get('location');
+
+  const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    if (value) params.set('sort', value); else params.delete('sort');
+    navigate({ pathname: '/listings', search: params.toString() });
+  };
+
+  useEffect(() => {
+    setPage(1);
+  }, [location.search]);
+
+  const handleClear = () => {
+    navigate('/listings');
+    setSelectedId(null);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleMarkerSelect = (id: number) => {
+    setSelectedId(id);
+    const el = document.getElementById(`listing-${id}`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const handleListingClick = (id: number) => {
+    setSelectedId(id);
+  };
+
+  const start = (page - 1) * ITEMS_PER_PAGE;
+  const pageListings = listings.slice(start, start + ITEMS_PER_PAGE);
+  const totalPages = Math.ceil(listings.length / ITEMS_PER_PAGE) || 1;
+
+  const changePage = (p: number) => {
+    setPage(p);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <div className="listings-container">
+      <Header />
+      <div className="pt-24 px-4 listings-layout">
+        <div className="listings-list pr-4">
+          <div className="flex justify-between items-center mb-4">
+            <select value={sortParam} onChange={handleSortChange} className="border p-2 rounded-md bg-white">
+              <option value="">Recommended</option>
+              <option value="asc">Lowest Price First</option>
+              <option value="desc">Highest Price First</option>
+            </select>
+            <button onClick={handleClear} className="ml-4 bg-[#4CAF87] text-white px-4 py-2 rounded-md">Clear Filters</button>
+          </div>
+          {pageListings.map((listing) => (
+            <ListingCard
+              key={listing.id}
+              listing={listing}
+              selected={selectedId === listing.id}
+              onClick={() => handleListingClick(listing.id)}
+            />
+          ))}
+          {totalPages > 1 && (
+            <div className="flex justify-center items-center gap-4 my-4">
+              <button
+                disabled={page === 1}
+                onClick={() => changePage(page - 1)}
+                className="px-3 py-1 bg-white border rounded disabled:opacity-50"
+              >
+                Prev
+              </button>
+              <span>
+                {page} / {totalPages}
+              </span>
+              <button
+                disabled={page === totalPages}
+                onClick={() => changePage(page + 1)}
+                className="px-3 py-1 bg-white border rounded disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="listings-map mt-4 md:mt-0">
+          <MapPanel
+            listings={listings}
+            selectedId={selectedId}
+            onSelect={handleMarkerSelect}
+            locationParam={locationParam}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ListingsPage;

--- a/src/styles/Listings.css
+++ b/src/styles/Listings.css
@@ -1,0 +1,34 @@
+.listings-container {
+  background: #FFF7EB;
+  min-height: 100vh;
+}
+
+.listing-marker div {
+  width: 16px;
+  height: 16px;
+  background: #2E7BF6;
+  border: 2px solid #fff;
+  border-radius: 50%;
+}
+
+.listing-marker.selected div {
+  background: #4CAF87;
+}
+
+.listings-map {
+  height: 300px;
+}
+
+@media (min-width: 768px) {
+  .listings-layout {
+    display: flex;
+  }
+  .listings-list {
+    flex: 1;
+    overflow-y: auto;
+  }
+  .listings-map {
+    flex: 1;
+    height: calc(100vh - 80px);
+  }
+}


### PR DESCRIPTION
## Summary
- add mock listings dataset and data hook with API fallback
- create listings page with map, sorting, pagination, and clear filters
- integrate search bar with query params and navigation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f08ca737c832687876d64672aed00