### PR TITLE
feat: listings page with search filters and map

### DIFF
--- a/.screen-graph.json
+++ b/.screen-graph.json
@@ -1,4 +1,21 @@
 {
-  "nodes": [],
+  "nodes": [
+    {
+      "id": "src/screens/House/House.tsx",
+      "label": "House",
+      "routes": [
+        "/"
+      ],
+      "dataModelId": "2060:120",
+      "isRoot": true
+    },
+    {
+      "id": "src/pages/listings.tsx",
+      "label": "listings",
+      "routes": [
+        "/listings"
+      ]
+    }
+  ],
   "edges": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "@radix-ui/react-slot": "^1.1.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "2.1.1",
+        "leaflet": "^1.9.4",
         "lucide-react": "^0.453.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-leaflet": "^4.2.1",
         "react-router-dom": "^6.8.1",
         "tailwind-merge": "2.5.4",
         "tailwind-scrollbar-hide": "latest",
@@ -22,6 +24,7 @@
       },
       "devDependencies": {
         "@animaapp/vite-plugin-screen-graph": "^0.1.5",
+        "@types/leaflet": "^1.9.20",
         "@types/react": "18.2.0",
         "@types/react-dom": "18.2.0",
         "@vitejs/plugin-react": "4.3.4",
@@ -1428,6 +1431,17 @@
         }
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1768,6 +1782,23 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.20",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
+      "integrity": "sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2468,6 +2499,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -2898,6 +2935,20 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -9,20 +9,23 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@radix-ui/react-separator": "^1.1.0",
+    "@radix-ui/react-slot": "^1.1.0",
+    "class-variance-authority": "^0.7.0",
     "clsx": "2.1.1",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.453.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.8.1",
     "tailwind-merge": "2.5.4",
-    "tailwindcss-animate": "1.0.7",
-    "@radix-ui/react-slot": "^1.1.0",
-    "class-variance-authority": "^0.7.0",
-    "@radix-ui/react-separator": "^1.1.0",
-    "tailwind-scrollbar-hide": "latest"
+    "tailwind-scrollbar-hide": "latest",
+    "tailwindcss-animate": "1.0.7"
   },
   "devDependencies": {
     "@animaapp/vite-plugin-screen-graph": "^0.1.5",
+    "@types/leaflet": "^1.9.20",
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.0",
     "@vitejs/plugin-react": "4.3.4",

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Listing } from '../hooks/useListingsData';
+
+interface ListingCardProps {
+  listing: Listing;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+const ListingCard: React.FC<ListingCardProps> = ({ listing, selected, onClick }) => {
+  return (
+    <div
+      onClick={onClick}
+      className={`rounded-lg overflow-hidden shadow-md mb-4 cursor-pointer transition-transform transform hover:scale-[1.02] bg-white ${selected ? 'ring-4 ring-[#4CAF87]' : ''}`}
+    >
+      <img
+        src={listing.image}
+        alt={listing.title}
+        className="w-full h-48 object-cover"
+      />
+      <div className="p-4">
+        <h3 className="text-lg font-bold text-gray-800 mb-1">{listing.title}</h3>
+        <p className="text-sm text-gray-600 mb-2">{listing.location}</p>
+        <p className="text-[#4CAF87] font-semibold">CA$ {listing.price}/month</p>
+        <p className="text-sm text-gray-600">{listing.guests} guest{listing.guests !== 1 ? 's' : ''}</p>
+      </div>
+    </div>
+  );
+};
+
+export default ListingCard;

--- a/src/components/MapPanel.tsx
+++ b/src/components/MapPanel.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import { MapContainer, TileLayer, CircleMarker, useMap } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Listing } from '../hooks/useListingsData';
+
+interface MapPanelProps {
+  listings: Listing[];
+  selectedId: number | null;
+  onMarkerClick: (id: number) => void;
+  locationQuery?: string | null;
+}
+
+const FitBounds: React.FC<{ listings: Listing[]; selectedId: number | null; locationQuery?: string | null; }> = ({ listings, selectedId, locationQuery }) => {
+  const map = useMap();
+  useEffect(() => {
+    if (selectedId) {
+      const listing = listings.find((l) => l.id === selectedId);
+      if (listing) {
+        map.setView([listing.coordinates.lat, listing.coordinates.lng], 13);
+        return;
+      }
+    }
+    if (locationQuery) {
+      const listing = listings.find((l) =>
+        l.location.toLowerCase().includes(locationQuery.toLowerCase())
+      );
+      if (listing) {
+        map.setView([listing.coordinates.lat, listing.coordinates.lng], 11);
+        return;
+      }
+    }
+    if (listings.length) {
+      const bounds = listings.map((l) => [l.coordinates.lat, l.coordinates.lng]) as [number, number][];
+      map.fitBounds(bounds, { padding: [50, 50] });
+    }
+  }, [listings, selectedId, locationQuery, map]);
+  return null;
+};
+
+const MapPanel: React.FC<MapPanelProps> = ({ listings, selectedId, onMarkerClick, locationQuery }) => {
+
+  return (
+    <MapContainer
+      center={[45, -75]}
+      zoom={4}
+      className="w-full h-96 md:h-[calc(100vh-100px)]"
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      {listings.map((l) => (
+        <CircleMarker
+          key={l.id}
+          center={[l.coordinates.lat, l.coordinates.lng]}
+          pathOptions={{ color: selectedId === l.id ? '#4CAF87' : '#3388ff', fillColor: selectedId === l.id ? '#4CAF87' : '#3388ff', fillOpacity: 1 }}
+          radius={10}
+          eventHandlers={{ click: () => onMarkerClick(l.id) }}
+        />
+      ))}
+      <FitBounds listings={listings} selectedId={selectedId} locationQuery={locationQuery} />
+    </MapContainer>
+  );
+};
+
+export default MapPanel;

--- a/src/data/mockListings.ts
+++ b/src/data/mockListings.ts
@@ -1,0 +1,38 @@
+export const mockListings = [
+  {
+    id: 1,
+    title: "Modern Condo in Downtown Toronto",
+    location: "Toronto, Canada",
+    price: 1800,
+    guests: 2,
+    image: "/images/listing1.jpg",
+    coordinates: { lat: 43.6532, lng: -79.3832 }
+  },
+  {
+    id: 2,
+    title: "Cozy Apartment in Vancouver",
+    location: "Vancouver, Canada",
+    price: 1500,
+    guests: 4,
+    image: "/images/listing2.jpg",
+    coordinates: { lat: 49.2827, lng: -123.1207 }
+  },
+  {
+    id: 3,
+    title: "Luxury Home in Montreal",
+    location: "Montreal, Canada",
+    price: 2500,
+    guests: 5,
+    image: "/images/listing3.jpg",
+    coordinates: { lat: 45.5017, lng: -73.5673 }
+  },
+  {
+    id: 4,
+    title: "Calgary Family House",
+    location: "Calgary, Canada",
+    price: 1300,
+    guests: 3,
+    image: "/images/listing4.jpg",
+    coordinates: { lat: 51.0447, lng: -114.0719 }
+  }
+];

--- a/src/hooks/useListingsData.ts
+++ b/src/hooks/useListingsData.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { mockListings } from '../data/mockListings';
+
+export interface Listing {
+  id: number;
+  title: string;
+  location: string;
+  price: number;
+  guests: number;
+  image: string;
+  coordinates: { lat: number; lng: number };
+}
+
+const parsePriceRange = (price?: string | null) => {
+  if (!price) return null;
+  const [min, max] = price.split('-').map((p) => parseInt(p, 10));
+  return { min, max };
+};
+
+const useListingsData = () => {
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const fetchListings = async () => {
+      let data: Listing[] = [];
+      try {
+        const res = await fetch('/api/listings');
+        if (res.ok) {
+          const json = await res.json();
+          if (Array.isArray(json) && json.length) {
+            data = json;
+          }
+        }
+      } catch {
+        // ignore network errors
+      }
+      if (!data.length) {
+        data = mockListings;
+      }
+
+      const location = searchParams.get('location');
+      const price = parsePriceRange(searchParams.get('price'));
+      const guests = parseInt(searchParams.get('guests') || '0', 10);
+      const sort = searchParams.get('sort');
+
+      let filtered = data;
+      if (location) {
+        filtered = filtered.filter((l) =>
+          l.location.toLowerCase().includes(location.toLowerCase())
+        );
+      }
+      if (price) {
+        filtered = filtered.filter(
+          (l) => l.price >= price.min && l.price <= price.max
+        );
+      }
+      if (guests) {
+        filtered = filtered.filter((l) => l.guests >= guests);
+      }
+      if (sort === 'asc') {
+        filtered = filtered.slice().sort((a, b) => a.price - b.price);
+      } else if (sort === 'desc') {
+        filtered = filtered.slice().sort((a, b) => b.price - a.price);
+      }
+
+      setListings(filtered);
+    };
+    fetchListings();
+  }, [searchParams]);
+
+  return listings;
+};
+
+export default useListingsData;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,16 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { House } from "./screens/House";
+import ListingsPage from "./pages/listings";
 
 createRoot(document.getElementById("app") as HTMLElement).render(
   <StrictMode>
-    <House />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<House />} />
+        <Route path="/listings" element={<ListingsPage />} />
+      </Routes>
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/src/pages/listings.tsx
+++ b/src/pages/listings.tsx
@@ -1,0 +1,120 @@
+import React, { useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import Header from '../components/Header';
+import ListingCard from '../components/ListingCard';
+import MapPanel from '../components/MapPanel';
+import useListingsData from '../hooks/useListingsData';
+import '../styles/Listings.css';
+
+const ITEMS_PER_PAGE = 12;
+
+const ListingsPage: React.FC = () => {
+  const listings = useListingsData();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [page, setPage] = useState(1);
+  const listRefs = useRef<Record<number, HTMLDivElement | null>>({});
+
+  const handleMarkerClick = (id: number) => {
+    const el = listRefs.current[id];
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+    setSelectedId(id);
+  };
+
+  const handleListingClick = (id: number) => {
+    setSelectedId(id);
+  };
+
+  const sort = searchParams.get('sort') || '';
+  const locationQuery = searchParams.get('location');
+
+  const changeSort = (value: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (value) {
+      params.set('sort', value);
+    } else {
+      params.delete('sort');
+    }
+    setSearchParams(params);
+  };
+
+  const clearFilters = () => {
+    setSearchParams({});
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const start = (page - 1) * ITEMS_PER_PAGE;
+  const paginated = listings.slice(start, start + ITEMS_PER_PAGE);
+  const totalPages = Math.ceil(listings.length / ITEMS_PER_PAGE) || 1;
+
+  return (
+    <div className="listings-page min-h-screen">
+      <Header />
+      <div className="pt-[100px] px-4 md:px-6 flex flex-col md:flex-row gap-4">
+        <div className="flex-1">
+          <div className="flex justify-between items-center mb-4">
+            <select
+              value={sort}
+              onChange={(e) => changeSort(e.target.value)}
+              className="border rounded p-2"
+            >
+              <option value="">Recommended</option>
+              <option value="asc">Lowest Price First</option>
+              <option value="desc">Highest Price First</option>
+            </select>
+            <button
+              onClick={clearFilters}
+              className="text-[#4CAF87] underline"
+            >
+              Clear Filters
+            </button>
+          </div>
+          <div className="listings-grid">
+            {paginated.map((l) => (
+              <div
+                key={l.id}
+                ref={(el) => (listRefs.current[l.id] = el)}
+                onClick={() => handleListingClick(l.id)}
+              >
+                <ListingCard listing={l} selected={selectedId === l.id} />
+              </div>
+            ))}
+          </div>
+          {totalPages > 1 && (
+            <div className="flex justify-center items-center gap-4 mt-4">
+              <button
+                disabled={page === 1}
+                onClick={() => setPage((p) => p - 1)}
+                className="px-3 py-1 border rounded disabled:opacity-50"
+              >
+                Prev
+              </button>
+              <span className="text-sm">
+                Page {page} / {totalPages}
+              </span>
+              <button
+                disabled={page === totalPages}
+                onClick={() => setPage((p) => p + 1)}
+                className="px-3 py-1 border rounded disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="md:w-1/2">
+          <MapPanel
+            listings={listings}
+            selectedId={selectedId}
+            onMarkerClick={handleMarkerClick}
+            locationQuery={locationQuery}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ListingsPage;

--- a/src/styles/Listings.css
+++ b/src/styles/Listings.css
@@ -1,0 +1,14 @@
+.listings-page {
+  background-color: #FFF7EB;
+}
+
+.listings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.map-container {
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
## Summary
- add listings page that supports filter params, sorting, pagination and map sync
- integrate search bar with query string navigation
- include mock listings data with API fallback hook

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f08ca737c832687876d64672aed00