### PR TITLE
Add property details and marketing sections

### DIFF
--- a/.screen-graph.json
+++ b/.screen-graph.json
@@ -10,29 +10,47 @@
       "isRoot": true
     },
     {
-      "id": "src/pages/listings.tsx",
-      "label": "listings",
+      "id": "src/pages/listings/500-halderfair-tower.tsx",
+      "label": "500-halderfair-tower",
       "routes": [
-        "/listings"
+        "/listings/500-halderfair-tower"
+      ]
+    },
+    {
+      "id": "src/pages/listings/54-ferrinhill-street.tsx",
+      "label": "54-ferrinhill-street",
+      "routes": [
+        "/listings/54-ferrinhill-street"
+      ]
+    },
+    {
+      "id": "src/pages/listings/23-siennalane-hill.tsx",
+      "label": "23-siennalane-hill",
+      "routes": [
+        "/listings/23-siennalane-hill"
+      ]
+    },
+    {
+      "id": "src/pages/listings/789-maple-street.tsx",
+      "label": "789-maple-street",
+      "routes": [
+        "/listings/789-maple-street"
+      ]
+    },
+    {
+      "id": "src/pages/listings/456-oak-avenue.tsx",
+      "label": "456-oak-avenue",
+      "routes": [
+        "/listings/456-oak-avenue"
+      ]
+    },
+    {
+      "id": "src/pages/listings/123-pine-road.tsx",
+      "label": "123-pine-road",
+      "routes": [
+        "/listings/123-pine-road"
       ]
     }
   ],
-  "edges": [
-    {
-      "id": "src/pages/listings.tsx:26:4-to-src/pages/listings.tsx",
-      "source": "src/pages/listings.tsx",
-      "target": "src/pages/listings.tsx",
-      "data": {
-        "viaRoute": "/listings",
-        "trigger": {
-          "element": "navigate('/listings')",
-          "line": 26,
-          "endLine": 26,
-          "column": 4,
-          "endColumn": 25,
-          "sourceFile": "src/pages/listings.tsx"
-        }
-      }
-    }
-  ]
+  "edges": []
 }

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from './ui/button';
+
+const CTASection: React.FC = () => {
+  return (
+    <section className="w-full bg-[#FFF7EB]">
+      <div className="container py-16 text-center">
+        <h2 className="mb-6 [font-family:'Golos_Text',Helvetica] font-semibold text-black text-2xl md:text-3xl lg:text-[40px] tracking-[0]">
+          Start your journey today.
+        </h2>
+        <p className="mb-8 [font-family:'Golos_Text',Helvetica] text-[#6b6b6b] text-lg md:text-xl lg:text-[25px] leading-relaxed">
+          Browse our growing collection of properties and secure your next home in Canada.
+        </p>
+        <Link to="/listings">
+          <Button className="h-[55px] md:h-[65px] lg:h-[72px] w-[280px] md:w-[300px] lg:w-[328px] bg-[#4CAF87] rounded-[30px] md:rounded-[35px] lg:rounded-[43px] [font-family:'Golos_Text',Helvetica] font-medium text-white text-lg md:text-xl lg:text-2xl tracking-[-1px] hover:bg-[#3b9b73] transition-colors">
+            Find Your Home
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default CTASection;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -17,11 +17,11 @@ const HeroSection: React.FC = () => {
           {/* Hero Content */}
           <div className="flex-1 pt-16 md:pt-24 lg:pt-40 text-center lg:text-left">
             <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-4xl md:text-6xl lg:text-8xl tracking-[-2px] md:tracking-[-4px] lg:tracking-[-5.76px] leading-tight md:leading-[1.1] lg:leading-[84.3px] mb-6 md:mb-8 lg:mb-10">
-              Welcome To Your <br />
+              Welcome to Your <br />
               Canadian Dream
             </h1>
             <p className="w-full max-w-[400px] md:max-w-[500px] lg:max-w-[522px] mx-auto lg:mx-0 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-lg md:text-2xl lg:text-[32px] tracking-[-1px] md:tracking-[-1.5px] lg:tracking-[-1.92px] leading-relaxed md:leading-[1.2] lg:leading-[28.1px] mb-8 md:mb-10 lg:mb-12">
-              At the frontier of the living lavish lifestyle in Canada
+              Find your perfect home at the frontier of Canada’s lavish living. Whether you’re a newcomer, student, or simply seeking a fresh start, Tempho makes it easy to discover secure, stylish, and affordable furnished rentals—all in one place.
             </p>
 
             <Button
@@ -36,6 +36,9 @@ const HeroSection: React.FC = () => {
                 />
               </div>
             </Button>
+            <p className="mt-4 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-sm md:text-base">
+              Trusted by many, with over CA$150K+ in revenue and growing.
+            </p>
           </div>
 
           {/* Hero Image Section - Hidden on mobile, visible on large screens */}

--- a/src/components/ListingDetail.tsx
+++ b/src/components/ListingDetail.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { PropertyListing } from '../data/listings';
+import { Button } from './ui/button';
+
+interface ListingDetailProps {
+  property: PropertyListing;
+}
+
+const ListingDetail: React.FC<ListingDetailProps> = ({ property }) => {
+  return (
+    <div className="container py-12 md:py-18 lg:py-24">
+      <div className="mb-8">
+        <img
+          src={property.imageUrl}
+          alt={property.address}
+          className="w-full h-[300px] md:h-[400px] lg:h-[500px] object-cover rounded-xl"
+        />
+      </div>
+      <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-2xl md:text-3xl lg:text-[40px] mb-4">
+        {property.address}
+      </h1>
+      <div className="[font-family:'Golos_Text',Helvetica] text-[#6b6b6b] text-lg md:text-xl lg:text-[25px] mb-4">
+        {property.price} — {property.propertyType}
+      </div>
+      <div className="[font-family:'Golos_Text',Helvetica] text-black text-base md:text-lg mb-6">
+        {property.beds} Bed{property.beds !== 1 ? 's' : ''} | {property.baths} Bath{property.baths !== 1 ? 's' : ''} | {property.garage}-Car Garage
+      </div>
+      <p className="mb-8 [font-family:'Golos_Text',Helvetica] text-[#6b6b6b] text-base md:text-lg leading-relaxed">
+        This is a beautiful property located in the heart of the city. It offers modern amenities and a comfortable living experience for its residents.
+      </p>
+      <Button className="bg-[#4CAF87] hover:bg-[#3b9b73] [font-family:'Golos_Text',Helvetica] text-white rounded-full px-8 py-4">
+        Contact / Book Now
+      </Button>
+    </div>
+  );
+};
+
+export default ListingDetail;

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Card, CardContent } from './ui/card';
 import { PropertyListing } from '../data/listings';
 
@@ -8,43 +9,45 @@ interface PropertyCardProps {
 
 export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
   return (
-    <Card className="w-[280px] md:w-[320px] lg:w-[360px] h-auto bg-transparent border-none shadow-none flex-shrink-0 cursor-pointer group">
-      <CardContent className="p-0">
-        {/* Property Image */}
-        <div className="relative overflow-hidden rounded-xl mb-3">
-          <img
-            className="w-full h-[200px] md:h-[240px] lg:h-[280px] object-cover transition-transform duration-300 group-hover:scale-105"
-            alt={`${property.propertyType} property`}
-            src={property.imageUrl}
-          />
-          {/* Hover overlay */}
-          <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300" />
-        </div>
-
-        {/* Property Details */}
-        <div className="space-y-1">
-          {/* Price */}
-          <div className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-lg md:text-xl lg:text-2xl tracking-[0.8px] md:tracking-[1px] lg:tracking-[1.20px] leading-tight">
-            {property.price}
+    <Link to={`/listings/${property.slug}`} className="block">
+      <Card className="w-[280px] md:w-[320px] lg:w-[360px] h-auto bg-transparent border-none shadow-none flex-shrink-0 cursor-pointer group">
+        <CardContent className="p-0">
+          {/* Property Image */}
+          <div className="relative overflow-hidden rounded-xl mb-3">
+            <img
+              className="w-full h-[200px] md:h-[240px] lg:h-[280px] object-cover transition-transform duration-300 group-hover:scale-105"
+              alt={`${property.propertyType} property`}
+              src={property.imageUrl}
+            />
+            {/* Hover overlay */}
+            <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300" />
           </div>
 
-          {/* Property Type */}
-          <div className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-base md:text-lg lg:text-xl tracking-[0.6px] md:tracking-[0.8px] lg:tracking-[1.20px] leading-tight">
-            {property.propertyType}
-          </div>
+          {/* Property Details */}
+          <div className="space-y-1">
+            {/* Price */}
+            <div className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-lg md:text-xl lg:text-2xl tracking-[0.8px] md:tracking-[1px] lg:tracking-[1.20px] leading-tight">
+              {property.price}
+            </div>
 
-          {/* Address */}
-          <div className="[font-family:'Golos_Text',Helvetica] font-semibold text-[#ffc369] text-lg md:text-xl lg:text-2xl leading-tight tracking-[0]">
-            {property.address}
-          </div>
+            {/* Property Type */}
+            <div className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-base md:text-lg lg:text-xl tracking-[0.6px] md:tracking-[0.8px] lg:tracking-[1.20px] leading-tight">
+              {property.propertyType}
+            </div>
 
-          {/* Property Features */}
-          <div className="[font-family:'Golos_Text',Helvetica] font-normal text-black text-sm md:text-base leading-relaxed tracking-[0] pt-1">
-            {property.beds} Bed{property.beds !== 1 ? 's' : ''} | {property.baths} Bath{property.baths !== 1 ? 's' : ''} | {property.garage}-Car Garage
+            {/* Address */}
+            <div className="[font-family:'Golos_Text',Helvetica] font-semibold text-[#ffc369] text-lg md:text-xl lg:text-2xl leading-tight tracking-[0]">
+              {property.address}
+            </div>
+
+            {/* Property Features */}
+            <div className="[font-family:'Golos_Text',Helvetica] font-normal text-black text-sm md:text-base leading-relaxed tracking-[0] pt-1">
+              {property.beds} Bed{property.beds !== 1 ? 's' : ''} | {property.baths} Bath{property.baths !== 1 ? 's' : ''} | {property.garage}-Car Garage
+            </div>
           </div>
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </Link>
   );
 };
 

--- a/src/components/WhyChooseTempho.tsx
+++ b/src/components/WhyChooseTempho.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { ShieldCheck, Calendar, Users, Search } from 'lucide-react';
+
+const features = [
+  {
+    icon: ShieldCheck,
+    title: 'Verified & Safe',
+    description: 'Every listing is vetted to ensure peace of mind.',
+  },
+  {
+    icon: Calendar,
+    title: 'Flexible Terms',
+    description: 'Options for monthly rentals and beyond.',
+  },
+  {
+    icon: Users,
+    title: 'For Everyone',
+    description: 'Perfect for newcomers, students, families, and professionals.',
+  },
+  {
+    icon: Search,
+    title: 'Simple Search',
+    description: 'Filter by location, budget, and amenities with ease.',
+  },
+];
+
+const WhyChooseTempho: React.FC = () => {
+  return (
+    <section className="w-full bg-white" id="why-tempho">
+      <div className="container py-12 md:py-18 lg:py-24">
+        <h2 className="mb-8 [font-family:'Golos_Text',Helvetica] font-semibold text-black text-2xl md:text-3xl lg:text-[40px] tracking-[0]">
+          Why Choose Tempho?
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {features.map((feature) => (
+            <div key={feature.title} className="flex items-start space-x-4">
+              <feature.icon className="w-6 h-6 md:w-8 md:h-8 text-[#4CAF87] flex-shrink-0" />
+              <div className="[font-family:'Golos_Text',Helvetica]">
+                <h3 className="font-medium text-black text-lg md:text-xl mb-1">
+                  {feature.title}
+                </h3>
+                <p className="text-[#6b6b6b] text-sm md:text-base leading-relaxed">
+                  {feature.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default WhyChooseTempho;

--- a/src/data/listings.ts
+++ b/src/data/listings.ts
@@ -7,6 +7,7 @@ export interface PropertyListing {
   beds: number;
   baths: number;
   garage: number;
+  slug: string;
 }
 
 export const propertyListings: PropertyListing[] = [
@@ -19,6 +20,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 2,
     baths: 2,
     garage: 1,
+    slug: "500-halderfair-tower",
   },
   {
     id: 2,
@@ -29,6 +31,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 2,
     baths: 2,
     garage: 1,
+    slug: "54-ferrinhill-street",
   },
   {
     id: 3,
@@ -39,6 +42,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 3,
     baths: 2,
     garage: 1,
+    slug: "23-siennalane-hill",
   },
   {
     id: 4,
@@ -49,6 +53,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 3,
     baths: 2,
     garage: 2,
+    slug: "789-maple-street",
   },
   {
     id: 5,
@@ -59,6 +64,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 4,
     baths: 3,
     garage: 2,
+    slug: "456-oak-avenue",
   },
   {
     id: 6,
@@ -69,6 +75,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 1,
     baths: 1,
     garage: 1,
+    slug: "123-pine-road",
   },
 ];
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,12 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { House } from "./screens/House";
 import ListingsPage from "./pages/listings";
+import HalderfairTowerPage from "./pages/listings/500-halderfair-tower";
+import FerrinhillStreetPage from "./pages/listings/54-ferrinhill-street";
+import SiennalaneHillPage from "./pages/listings/23-siennalane-hill";
+import MapleStreetPage from "./pages/listings/789-maple-street";
+import OakAvenuePage from "./pages/listings/456-oak-avenue";
+import PineRoadPage from "./pages/listings/123-pine-road";
 
 createRoot(document.getElementById("app") as HTMLElement).render(
   <StrictMode>
@@ -10,6 +16,12 @@ createRoot(document.getElementById("app") as HTMLElement).render(
       <Routes>
         <Route path="/" element={<House />} />
         <Route path="/listings" element={<ListingsPage />} />
+        <Route path="/listings/500-halderfair-tower" element={<HalderfairTowerPage />} />
+        <Route path="/listings/54-ferrinhill-street" element={<FerrinhillStreetPage />} />
+        <Route path="/listings/23-siennalane-hill" element={<SiennalaneHillPage />} />
+        <Route path="/listings/789-maple-street" element={<MapleStreetPage />} />
+        <Route path="/listings/456-oak-avenue" element={<OakAvenuePage />} />
+        <Route path="/listings/123-pine-road" element={<PineRoadPage />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/src/pages/listings/123-pine-road.tsx
+++ b/src/pages/listings/123-pine-road.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Header from '../../components/Header';
+import ListingDetail from '../../components/ListingDetail';
+import { propertyListings } from '../../data/listings';
+
+const property = propertyListings.find((p) => p.slug === '123-pine-road')!;
+
+const PineRoadPage: React.FC = () => {
+  return (
+    <div className="bg-[#FFF7EB] min-h-screen">
+      <Header />
+      <ListingDetail property={property} />
+    </div>
+  );
+};
+
+export default PineRoadPage;

--- a/src/pages/listings/23-siennalane-hill.tsx
+++ b/src/pages/listings/23-siennalane-hill.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Header from '../../components/Header';
+import ListingDetail from '../../components/ListingDetail';
+import { propertyListings } from '../../data/listings';
+
+const property = propertyListings.find((p) => p.slug === '23-siennalane-hill')!;
+
+const SiennalaneHillPage: React.FC = () => {
+  return (
+    <div className="bg-[#FFF7EB] min-h-screen">
+      <Header />
+      <ListingDetail property={property} />
+    </div>
+  );
+};
+
+export default SiennalaneHillPage;

--- a/src/pages/listings/456-oak-avenue.tsx
+++ b/src/pages/listings/456-oak-avenue.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Header from '../../components/Header';
+import ListingDetail from '../../components/ListingDetail';
+import { propertyListings } from '../../data/listings';
+
+const property = propertyListings.find((p) => p.slug === '456-oak-avenue')!;
+
+const OakAvenuePage: React.FC = () => {
+  return (
+    <div className="bg-[#FFF7EB] min-h-screen">
+      <Header />
+      <ListingDetail property={property} />
+    </div>
+  );
+};
+
+export default OakAvenuePage;

--- a/src/pages/listings/500-halderfair-tower.tsx
+++ b/src/pages/listings/500-halderfair-tower.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Header from '../../components/Header';
+import ListingDetail from '../../components/ListingDetail';
+import { propertyListings } from '../../data/listings';
+
+const property = propertyListings.find((p) => p.slug === '500-halderfair-tower')!;
+
+const HalderfairTowerPage: React.FC = () => {
+  return (
+    <div className="bg-[#FFF7EB] min-h-screen">
+      <Header />
+      <ListingDetail property={property} />
+    </div>
+  );
+};
+
+export default HalderfairTowerPage;

--- a/src/pages/listings/54-ferrinhill-street.tsx
+++ b/src/pages/listings/54-ferrinhill-street.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Header from '../../components/Header';
+import ListingDetail from '../../components/ListingDetail';
+import { propertyListings } from '../../data/listings';
+
+const property = propertyListings.find((p) => p.slug === '54-ferrinhill-street')!;
+
+const FerrinhillStreetPage: React.FC = () => {
+  return (
+    <div className="bg-[#FFF7EB] min-h-screen">
+      <Header />
+      <ListingDetail property={property} />
+    </div>
+  );
+};
+
+export default FerrinhillStreetPage;

--- a/src/pages/listings/789-maple-street.tsx
+++ b/src/pages/listings/789-maple-street.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Header from '../../components/Header';
+import ListingDetail from '../../components/ListingDetail';
+import { propertyListings } from '../../data/listings';
+
+const property = propertyListings.find((p) => p.slug === '789-maple-street')!;
+
+const MapleStreetPage: React.FC = () => {
+  return (
+    <div className="bg-[#FFF7EB] min-h-screen">
+      <Header />
+      <ListingDetail property={property} />
+    </div>
+  );
+};
+
+export default MapleStreetPage;

--- a/src/pages/listings/index.tsx
+++ b/src/pages/listings/index.tsx
@@ -1,10 +1,10 @@
 import React, { useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import Header from '../components/Header';
-import ListingCard from '../components/ListingCard';
-import MapPanel from '../components/MapPanel';
-import useListingsData from '../hooks/useListingsData';
-import '../styles/Listings.css';
+import Header from '../../components/Header';
+import ListingCard from '../../components/ListingCard';
+import MapPanel from '../../components/MapPanel';
+import useListingsData from '../../hooks/useListingsData';
+import '../../styles/Listings.css';
 
 export const ListingsPage: React.FC = () => {
   const { listings } = useListingsData();

--- a/src/screens/House/House.tsx
+++ b/src/screens/House/House.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Badge } from "../../components/ui/badge";
 import { ServicesSection } from "../../components/ServicesSection";
+import WhyChooseTempho from "../../components/WhyChooseTempho";
+import CTASection from "../../components/CTASection";
 import Header from "../../components/Header";
 import HeroSection from "../../components/HeroSection";
 
@@ -25,33 +27,16 @@ export const House = (): JSX.Element => {
             </div>
 
             <div className="space-y-6 md:space-y-8">
-              <p className="w-full max-w-none lg:max-w-[1043px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-xl md:text-2xl lg:text-[40px] leading-relaxed md:leading-[1.3] lg:leading-10 tracking-[0]">
-                Prevail in the subahs Turbo Pack is a new, high-performance bundler
-                designed to speed up development in Next.js. It's built by Vercel,
-                the creators of Next.js, and is intended to replace{" "}
-                <a
-                  href="https://www.google.com/search?sca_esv=12c7b01f52a29939&amp;rlz=1C1NDCM_enNG1030NG1030&amp;sxsrf=AE3TifNnBaIZBTcdMSmJJm3hmPwAzHy5qA%3A1753015930808&amp;q=Webpack&amp;sa=X&amp;ved=2ahUKEwi5sN2evcuOAxWSE1kFHbkcB-oQxccNegQIIxAB&amp;mstk=AUtExfBF0Z33ag7MkcoefjUTjtrCF9fF3FR54q6yJjlostu22nzvpJXZVV0LLqow4xrpnTvD_ung6IJfcq5f0THVaULczWVGKkNzYSin0Smr9nHwegWMhTR1O8XeetOqOGjAlrVyjMA86WiD8Lu_bxY5VfuyBdDV_tkHNPPR3vD8WCUn2VI&amp;csui=3"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  className="font-medium tracking-[0.5px] md:tracking-[0.8px] lg:tracking-[1.12px] leading-[1.3] lg:leading-[50.8px] underline hover:text-[#569b6f] transition-colors"
-                >
-                  Webpack
-                </a>{" "}
-                as the default bundler for Next.js applications.{" "}
+              <h2 className="w-full max-w-none lg:max-w-[1043px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-xl md:text-2xl lg:text-[40px] leading-relaxed md:leading-[1.3] lg:leading-10 tracking-[0]">
+                Your Gateway to Seamless Canadian Living
+              </h2>
+
+              <p className="ml-auto w-full max-w-none md:max-w-[600px] lg:max-w-[573px] [font-family:'Golos_Text',Helvetica] font-medium text-[#6b6b6b] text-lg md:text-xl lg:text-[25px] tracking-[0.3px] md:tracking-[0.4px] lg:tracking-[0.44px] leading-relaxed md:leading-[1.3] lg:leading-[31.8px]">
+                At Tempho, we believe finding a home should be simple, transparent, and stress-free. We connect you with high-quality, verified rental properties—offering flexible terms and tailored options to suit your needs.
               </p>
 
               <p className="ml-auto w-full max-w-none md:max-w-[600px] lg:max-w-[573px] [font-family:'Golos_Text',Helvetica] font-medium text-[#6b6b6b] text-lg md:text-xl lg:text-[25px] tracking-[0.3px] md:tracking-[0.4px] lg:tracking-[0.44px] leading-relaxed md:leading-[1.3] lg:leading-[31.8px]">
-                in{" "}
-                <a
-                  href="https://www.google.com/search?sca_esv=12c7b01f52a29939&amp;rlz=1C1NDCM_enNG1030NG1030&amp;sxsrf=AE3TifNnBaIZBTcdMSmJJm3hmPwAzHy5qA%3A1753015930808&amp;q=Rust&amp;sa=X&amp;ved=2ahUKEwi5sN2evcuOAxWSE1kFHbkcB-oQxccNegQINxAB&amp;mstk=AUtExfBF0Z33ag7MkcoefjUTjtrCF9fF3FR54q6yJjlostu22nzvpJXZVV0LLqow4xrpnTvD_ung6IJfcq5f0THVaULczWVGKkNzYSin0Smr9nHwegWMhTR1O8XeetOqOGjAlrVyjMA86WiD8Lu_bxY5VfuyBdDV_tkHNPPR3vD8WCUn2VI&amp;csui=3"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  className="underline hover:text-[#569b6f] transition-colors"
-                >
-                  Rust
-                </a>
-                , which allows it to leverage the language's speed and efficiency
-                for faster builds and more responsive development experiences
+                From modern condos to family townhouses, we combine local expertise with advanced tools to deliver an effortless rental experience.
               </p>
             </div>
           </div>
@@ -59,6 +44,12 @@ export const House = (): JSX.Element => {
 
         {/* Services Section with Airbnb-Style Carousel */}
         <ServicesSection />
+
+        {/* Why Choose Tempho Section */}
+        <WhyChooseTempho />
+
+        {/* Call to Action Section */}
+        <CTASection />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Revise hero and about us copy with new messaging and support line
- Replace services data, add Why Choose Tempho and CTA sections
- Introduce property detail pages and link property cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f1462ce788326bd926a88992848b4