### PR TITLE
Revamp homepage copy and add property detail pages

### DIFF
--- a/.screen-graph.json
+++ b/.screen-graph.json
@@ -10,29 +10,47 @@
       "isRoot": true
     },
     {
-      "id": "src/pages/listings.tsx",
-      "label": "listings",
+      "id": "src/pages/listings/500-halderfair-tower.tsx",
+      "label": "500-halderfair-tower",
       "routes": [
-        "/listings"
+        "/listings/500-halderfair-tower"
+      ]
+    },
+    {
+      "id": "src/pages/listings/54-ferrinhill-street.tsx",
+      "label": "54-ferrinhill-street",
+      "routes": [
+        "/listings/54-ferrinhill-street"
+      ]
+    },
+    {
+      "id": "src/pages/listings/23-siennalane-hill.tsx",
+      "label": "23-siennalane-hill",
+      "routes": [
+        "/listings/23-siennalane-hill"
+      ]
+    },
+    {
+      "id": "src/pages/listings/789-maple-street.tsx",
+      "label": "789-maple-street",
+      "routes": [
+        "/listings/789-maple-street"
+      ]
+    },
+    {
+      "id": "src/pages/listings/456-oak-avenue.tsx",
+      "label": "456-oak-avenue",
+      "routes": [
+        "/listings/456-oak-avenue"
+      ]
+    },
+    {
+      "id": "src/pages/listings/123-pine-road.tsx",
+      "label": "123-pine-road",
+      "routes": [
+        "/listings/123-pine-road"
       ]
     }
   ],
-  "edges": [
-    {
-      "id": "src/pages/listings.tsx:26:4-to-src/pages/listings.tsx",
-      "source": "src/pages/listings.tsx",
-      "target": "src/pages/listings.tsx",
-      "data": {
-        "viaRoute": "/listings",
-        "trigger": {
-          "element": "navigate('/listings')",
-          "line": 26,
-          "endLine": 26,
-          "column": 4,
-          "endColumn": 25,
-          "sourceFile": "src/pages/listings.tsx"
-        }
-      }
-    }
-  ]
+  "edges": []
 }

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Button } from './ui/button';
+
+const CTASection: React.FC = () => (
+  <section className="w-full bg-[#FFF7EB]">
+    <div className="container py-12 md:py-18 lg:py-24 text-center">
+      <h2 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-2xl md:text-3xl lg:text-4xl mb-4">
+        Start your journey today.
+      </h2>
+      <p className="[font-family:'Golos_Text',Helvetica] text-[#6b6b6b] text-lg md:text-xl lg:text-2xl mb-8 max-w-2xl mx-auto">
+        Browse our growing collection of properties and secure your next home in Canada.
+      </p>
+      <Button
+        onClick={() => (window.location.href = '/listings')}
+        className="relative h-[55px] md:h-[65px] lg:h-[72px] w-[220px] md:w-[240px] lg:w-[260px] bg-[#4CAF87] rounded-[30px] md:rounded-[35px] lg:rounded-[43px] [font-family:'Golos_Text',Helvetica] font-medium text-white text-lg md:text-xl lg:text-2xl tracking-[-1px] md:tracking-[-1.2px] lg:tracking-[-1.44px] hover:bg-[#3b9b73] transition-colors"
+      >
+        Find Your Home →
+      </Button>
+    </div>
+  </section>
+);
+
+export default CTASection;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -17,11 +17,11 @@ const HeroSection: React.FC = () => {
           {/* Hero Content */}
           <div className="flex-1 pt-16 md:pt-24 lg:pt-40 text-center lg:text-left">
             <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-4xl md:text-6xl lg:text-8xl tracking-[-2px] md:tracking-[-4px] lg:tracking-[-5.76px] leading-tight md:leading-[1.1] lg:leading-[84.3px] mb-6 md:mb-8 lg:mb-10">
-              Welcome To Your <br />
+              Welcome to Your <br />
               Canadian Dream
             </h1>
             <p className="w-full max-w-[400px] md:max-w-[500px] lg:max-w-[522px] mx-auto lg:mx-0 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-lg md:text-2xl lg:text-[32px] tracking-[-1px] md:tracking-[-1.5px] lg:tracking-[-1.92px] leading-relaxed md:leading-[1.2] lg:leading-[28.1px] mb-8 md:mb-10 lg:mb-12">
-              At the frontier of the living lavish lifestyle in Canada
+              Find your perfect home at the frontier of Canada’s lavish living. Whether you’re a newcomer, student, or simply seeking a fresh start, Tempho makes it easy to discover secure, stylish, and affordable furnished rentals—all in one place.
             </p>
 
             <Button
@@ -36,6 +36,9 @@ const HeroSection: React.FC = () => {
                 />
               </div>
             </Button>
+            <p className="mt-4 [font-family:'Golos_Text',Helvetica] text-sm md:text-base text-[#6f6f6f]">
+              Trusted by many, with over CA$150K+ in revenue and growing.
+            </p>
           </div>
 
           {/* Hero Image Section - Hidden on mobile, visible on large screens */}

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent } from './ui/card';
 import { PropertyListing } from '../data/listings';
+import { Link } from 'react-router-dom';
 
 interface PropertyCardProps {
   property: PropertyListing;
@@ -8,43 +9,45 @@ interface PropertyCardProps {
 
 export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
   return (
-    <Card className="w-[280px] md:w-[320px] lg:w-[360px] h-auto bg-transparent border-none shadow-none flex-shrink-0 cursor-pointer group">
-      <CardContent className="p-0">
-        {/* Property Image */}
-        <div className="relative overflow-hidden rounded-xl mb-3">
-          <img
-            className="w-full h-[200px] md:h-[240px] lg:h-[280px] object-cover transition-transform duration-300 group-hover:scale-105"
-            alt={`${property.propertyType} property`}
-            src={property.imageUrl}
-          />
-          {/* Hover overlay */}
-          <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300" />
-        </div>
-
-        {/* Property Details */}
-        <div className="space-y-1">
-          {/* Price */}
-          <div className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-lg md:text-xl lg:text-2xl tracking-[0.8px] md:tracking-[1px] lg:tracking-[1.20px] leading-tight">
-            {property.price}
+    <Link to={`/listings/${property.slug}`} className="block">
+      <Card className="w-[280px] md:w-[320px] lg:w-[360px] h-auto bg-transparent border-none shadow-none flex-shrink-0 cursor-pointer group">
+        <CardContent className="p-0">
+          {/* Property Image */}
+          <div className="relative overflow-hidden rounded-xl mb-3">
+            <img
+              className="w-full h-[200px] md:h-[240px] lg:h-[280px] object-cover transition-transform duration-300 group-hover:scale-105"
+              alt={`${property.propertyType} property`}
+              src={property.imageUrl}
+            />
+            {/* Hover overlay */}
+            <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300" />
           </div>
 
-          {/* Property Type */}
-          <div className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-base md:text-lg lg:text-xl tracking-[0.6px] md:tracking-[0.8px] lg:tracking-[1.20px] leading-tight">
-            {property.propertyType}
-          </div>
+          {/* Property Details */}
+          <div className="space-y-1">
+            {/* Price */}
+            <div className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-lg md:text-xl lg:text-2xl tracking-[0.8px] md:tracking-[1px] lg:tracking-[1.20px] leading-tight">
+              {property.price}
+            </div>
 
-          {/* Address */}
-          <div className="[font-family:'Golos_Text',Helvetica] font-semibold text-[#ffc369] text-lg md:text-xl lg:text-2xl leading-tight tracking-[0]">
-            {property.address}
-          </div>
+            {/* Property Type */}
+            <div className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-base md:text-lg lg:text-xl tracking-[0.6px] md:tracking-[0.8px] lg:tracking-[1.20px] leading-tight">
+              {property.propertyType}
+            </div>
 
-          {/* Property Features */}
-          <div className="[font-family:'Golos_Text',Helvetica] font-normal text-black text-sm md:text-base leading-relaxed tracking-[0] pt-1">
-            {property.beds} Bed{property.beds !== 1 ? 's' : ''} | {property.baths} Bath{property.baths !== 1 ? 's' : ''} | {property.garage}-Car Garage
+            {/* Address */}
+            <div className="[font-family:'Golos_Text',Helvetica] font-semibold text-[#ffc369] text-lg md:text-xl lg:text-2xl leading-tight tracking-[0]">
+              {property.address}
+            </div>
+
+            {/* Property Features */}
+            <div className="[font-family:'Golos_Text',Helvetica] font-normal text-black text-sm md:text-base leading-relaxed tracking-[0] pt-1">
+              {property.beds} Bed{property.beds !== 1 ? 's' : ''} | {property.baths} Bath{property.baths !== 1 ? 's' : ''} | {property.garage}-Car Garage
+            </div>
           </div>
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </Link>
   );
 };
 

--- a/src/components/PropertyDetail.tsx
+++ b/src/components/PropertyDetail.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Header from './Header';
+import { Button } from './ui/button';
+import { PropertyListing } from '../data/listings';
+
+interface PropertyDetailProps {
+  property: PropertyListing;
+}
+
+const PropertyDetail: React.FC<PropertyDetailProps> = ({ property }) => (
+  <div className="bg-[#FFF7EB] min-h-screen">
+    <Header />
+    <div className="container pt-28 pb-16">
+      <img
+        src={property.imageUrl}
+        alt={property.address}
+        className="w-full h-64 md:h-96 object-cover rounded-xl mb-6"
+      />
+      <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-3xl md:text-4xl text-black mb-2">
+        {property.address}
+      </h1>
+      <p className="[font-family:'Golos_Text',Helvetica] text-xl md:text-2xl text-[#4CAF87] mb-4">
+        {property.price} — {property.propertyType}
+      </p>
+      <p className="[font-family:'Golos_Text',Helvetica] text-black text-lg mb-4">
+        {property.beds} Beds | {property.baths} Baths | {property.garage}-Car Garage
+      </p>
+      <p className="text-[#6b6b6b] mb-6">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at magna non nunc tristique rhoncus. Donec non semper nulla. Praesent vitae arcu tempor neque lacinia pretium. Proin viverra, ligula sit amet ultrices semper, ligula arcu tristique sapien, a accumsan nisi mauris ac eros.
+      </p>
+      <Button
+        onClick={() => (window.location.href = '/contact')}
+        className="bg-[#4CAF87] text-white [font-family:'Golos_Text',Helvetica]"
+      >
+        Contact / Book Now
+      </Button>
+    </div>
+  </div>
+);
+
+export default PropertyDetail;

--- a/src/components/WhyChooseTempho.tsx
+++ b/src/components/WhyChooseTempho.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Badge } from './ui/badge';
+import { ShieldCheck, CalendarCheck, Users, Search } from 'lucide-react';
+
+const features = [
+  {
+    icon: ShieldCheck,
+    title: 'Verified & Safe',
+    description: 'Every listing is vetted to ensure peace of mind.',
+  },
+  {
+    icon: CalendarCheck,
+    title: 'Flexible Terms',
+    description: 'Options for monthly rentals and beyond.',
+  },
+  {
+    icon: Users,
+    title: 'For Everyone',
+    description: 'Perfect for newcomers, students, families, and professionals.',
+  },
+  {
+    icon: Search,
+    title: 'Simple Search',
+    description: 'Filter by location, budget, and amenities with ease.',
+  },
+];
+
+const WhyChooseTempho: React.FC = () => (
+  <section className="w-full bg-white">
+    <div className="container py-12 md:py-18 lg:py-24">
+      <div className="flex items-center mb-6 md:mb-8">
+        <div className="w-3 h-3 bg-[#569b6f] rounded-md mr-4 md:mr-6 lg:mr-[22px] flex-shrink-0" />
+        <Badge className="bg-transparent [font-family:'Golos_Text',Helvetica] font-semibold text-[#569b6f] text-base md:text-lg lg:text-xl tracking-[1.5px] md:tracking-[2px] lg:tracking-[2.60px] leading-[1.2] lg:leading-[21.1px] p-0">
+          WHY CHOOSE TEMPHO?
+        </Badge>
+      </div>
+      <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+        {features.map((item) => (
+          <div key={item.title} className="flex flex-col items-center text-center space-y-4">
+            <item.icon className="w-12 h-12 text-[#4CAF87]" />
+            <h3 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-lg md:text-xl">
+              {item.title}
+            </h3>
+            <p className="[font-family:'Golos_Text',Helvetica] text-[#6b6b6b] text-sm md:text-base">
+              {item.description}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default WhyChooseTempho;

--- a/src/data/listings.ts
+++ b/src/data/listings.ts
@@ -1,5 +1,6 @@
 export interface PropertyListing {
   id: number;
+  slug: string;
   imageUrl: string;
   price: string;
   propertyType: string;
@@ -12,8 +13,9 @@ export interface PropertyListing {
 export const propertyListings: PropertyListing[] = [
   {
     id: 1,
+    slug: '500-halderfair-tower',
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-3.png",
-    price: "CA$ 1500/month",
+    price: "CA$1500/month",
     propertyType: "Condominium",
     address: "500 Halderfair Tower",
     beds: 2,
@@ -22,8 +24,9 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 2,
+    slug: '54-ferrinhill-street',
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-4.png",
-    price: "CA$ 1500/month",
+    price: "CA$1500/month",
     propertyType: "Apartment",
     address: "54 Ferrinhill Street",
     beds: 2,
@@ -32,8 +35,9 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 3,
+    slug: '23-siennalane-hill',
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-5.png",
-    price: "CA$ 1500/month",
+    price: "CA$1500/month",
     propertyType: "House",
     address: "23 Siennalane Hill",
     beds: 3,
@@ -42,8 +46,9 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 4,
+    slug: '789-maple-street',
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-3.png",
-    price: "CA$ 1800/month",
+    price: "CA$1800/month",
     propertyType: "Townhouse",
     address: "789 Maple Street",
     beds: 3,
@@ -52,8 +57,9 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 5,
+    slug: '456-oak-avenue',
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-4.png",
-    price: "CA$ 2200/month",
+    price: "CA$2200/month",
     propertyType: "Detached House",
     address: "456 Oak Avenue",
     beds: 4,
@@ -62,8 +68,9 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 6,
+    slug: '123-pine-road',
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-5.png",
-    price: "CA$ 1200/month",
+    price: "CA$1200/month",
     propertyType: "Studio",
     address: "123 Pine Road",
     beds: 1,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,12 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { House } from "./screens/House";
 import ListingsPage from "./pages/listings";
+import Listing500HalderfairTower from "./pages/listings/500-halderfair-tower";
+import Listing54FerrinhillStreet from "./pages/listings/54-ferrinhill-street";
+import Listing23SiennalaneHill from "./pages/listings/23-siennalane-hill";
+import Listing789MapleStreet from "./pages/listings/789-maple-street";
+import Listing456OakAvenue from "./pages/listings/456-oak-avenue";
+import Listing123PineRoad from "./pages/listings/123-pine-road";
 
 createRoot(document.getElementById("app") as HTMLElement).render(
   <StrictMode>
@@ -10,6 +16,12 @@ createRoot(document.getElementById("app") as HTMLElement).render(
       <Routes>
         <Route path="/" element={<House />} />
         <Route path="/listings" element={<ListingsPage />} />
+        <Route path="/listings/500-halderfair-tower" element={<Listing500HalderfairTower />} />
+        <Route path="/listings/54-ferrinhill-street" element={<Listing54FerrinhillStreet />} />
+        <Route path="/listings/23-siennalane-hill" element={<Listing23SiennalaneHill />} />
+        <Route path="/listings/789-maple-street" element={<Listing789MapleStreet />} />
+        <Route path="/listings/456-oak-avenue" element={<Listing456OakAvenue />} />
+        <Route path="/listings/123-pine-road" element={<Listing123PineRoad />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/src/pages/listings/123-pine-road.tsx
+++ b/src/pages/listings/123-pine-road.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetail from '../../components/PropertyDetail';
+
+const Listing123PineRoad: React.FC = () => {
+  const property = propertyListings.find((p) => p.slug === '123-pine-road');
+  if (!property) return null;
+  return <PropertyDetail property={property} />;
+};
+
+export default Listing123PineRoad;

--- a/src/pages/listings/23-siennalane-hill.tsx
+++ b/src/pages/listings/23-siennalane-hill.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetail from '../../components/PropertyDetail';
+
+const Listing23SiennalaneHill: React.FC = () => {
+  const property = propertyListings.find((p) => p.slug === '23-siennalane-hill');
+  if (!property) return null;
+  return <PropertyDetail property={property} />;
+};
+
+export default Listing23SiennalaneHill;

--- a/src/pages/listings/456-oak-avenue.tsx
+++ b/src/pages/listings/456-oak-avenue.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetail from '../../components/PropertyDetail';
+
+const Listing456OakAvenue: React.FC = () => {
+  const property = propertyListings.find((p) => p.slug === '456-oak-avenue');
+  if (!property) return null;
+  return <PropertyDetail property={property} />;
+};
+
+export default Listing456OakAvenue;

--- a/src/pages/listings/500-halderfair-tower.tsx
+++ b/src/pages/listings/500-halderfair-tower.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetail from '../../components/PropertyDetail';
+
+const Listing500HalderfairTower: React.FC = () => {
+  const property = propertyListings.find((p) => p.slug === '500-halderfair-tower');
+  if (!property) return null;
+  return <PropertyDetail property={property} />;
+};
+
+export default Listing500HalderfairTower;

--- a/src/pages/listings/54-ferrinhill-street.tsx
+++ b/src/pages/listings/54-ferrinhill-street.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetail from '../../components/PropertyDetail';
+
+const Listing54FerrinhillStreet: React.FC = () => {
+  const property = propertyListings.find((p) => p.slug === '54-ferrinhill-street');
+  if (!property) return null;
+  return <PropertyDetail property={property} />;
+};
+
+export default Listing54FerrinhillStreet;

--- a/src/pages/listings/789-maple-street.tsx
+++ b/src/pages/listings/789-maple-street.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetail from '../../components/PropertyDetail';
+
+const Listing789MapleStreet: React.FC = () => {
+  const property = propertyListings.find((p) => p.slug === '789-maple-street');
+  if (!property) return null;
+  return <PropertyDetail property={property} />;
+};
+
+export default Listing789MapleStreet;

--- a/src/pages/listings/index.tsx
+++ b/src/pages/listings/index.tsx
@@ -1,10 +1,10 @@
 import React, { useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import Header from '../components/Header';
-import ListingCard from '../components/ListingCard';
-import MapPanel from '../components/MapPanel';
-import useListingsData from '../hooks/useListingsData';
-import '../styles/Listings.css';
+import Header from '../../components/Header';
+import ListingCard from '../../components/ListingCard';
+import MapPanel from '../../components/MapPanel';
+import useListingsData from '../../hooks/useListingsData';
+import '../../styles/Listings.css';
 
 export const ListingsPage: React.FC = () => {
   const { listings } = useListingsData();

--- a/src/screens/House/House.tsx
+++ b/src/screens/House/House.tsx
@@ -3,6 +3,8 @@ import { Badge } from "../../components/ui/badge";
 import { ServicesSection } from "../../components/ServicesSection";
 import Header from "../../components/Header";
 import HeroSection from "../../components/HeroSection";
+import WhyChooseTempho from "../../components/WhyChooseTempho";
+import CTASection from "../../components/CTASection";
 
 export const House = (): JSX.Element => {
   return (
@@ -26,39 +28,29 @@ export const House = (): JSX.Element => {
 
             <div className="space-y-6 md:space-y-8">
               <p className="w-full max-w-none lg:max-w-[1043px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-xl md:text-2xl lg:text-[40px] leading-relaxed md:leading-[1.3] lg:leading-10 tracking-[0]">
-                Prevail in the subahs Turbo Pack is a new, high-performance bundler
-                designed to speed up development in Next.js. It's built by Vercel,
-                the creators of Next.js, and is intended to replace{" "}
-                <a
-                  href="https://www.google.com/search?sca_esv=12c7b01f52a29939&amp;rlz=1C1NDCM_enNG1030NG1030&amp;sxsrf=AE3TifNnBaIZBTcdMSmJJm3hmPwAzHy5qA%3A1753015930808&amp;q=Webpack&amp;sa=X&amp;ved=2ahUKEwi5sN2evcuOAxWSE1kFHbkcB-oQxccNegQIIxAB&amp;mstk=AUtExfBF0Z33ag7MkcoefjUTjtrCF9fF3FR54q6yJjlostu22nzvpJXZVV0LLqow4xrpnTvD_ung6IJfcq5f0THVaULczWVGKkNzYSin0Smr9nHwegWMhTR1O8XeetOqOGjAlrVyjMA86WiD8Lu_bxY5VfuyBdDV_tkHNPPR3vD8WCUn2VI&amp;csui=3"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  className="font-medium tracking-[0.5px] md:tracking-[0.8px] lg:tracking-[1.12px] leading-[1.3] lg:leading-[50.8px] underline hover:text-[#569b6f] transition-colors"
-                >
-                  Webpack
-                </a>{" "}
-                as the default bundler for Next.js applications.{" "}
+                Your Gateway to Seamless Canadian Living
               </p>
 
-              <p className="ml-auto w-full max-w-none md:max-w-[600px] lg:max-w-[573px] [font-family:'Golos_Text',Helvetica] font-medium text-[#6b6b6b] text-lg md:text-xl lg:text-[25px] tracking-[0.3px] md:tracking-[0.4px] lg:tracking-[0.44px] leading-relaxed md:leading-[1.3] lg:leading-[31.8px]">
-                in{" "}
-                <a
-                  href="https://www.google.com/search?sca_esv=12c7b01f52a29939&amp;rlz=1C1NDCM_enNG1030NG1030&amp;sxsrf=AE3TifNnBaIZBTcdMSmJJm3hmPwAzHy5qA%3A1753015930808&amp;q=Rust&amp;sa=X&amp;ved=2ahUKEwi5sN2evcuOAxWSE1kFHbkcB-oQxccNegQINxAB&amp;mstk=AUtExfBF0Z33ag7MkcoefjUTjtrCF9fF3FR54q6yJjlostu22nzvpJXZVV0LLqow4xrpnTvD_ung6IJfcq5f0THVaULczWVGKkNzYSin0Smr9nHwegWMhTR1O8XeetOqOGjAlrVyjMA86WiD8Lu_bxY5VfuyBdDV_tkHNPPR3vD8WCUn2VI&amp;csui=3"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  className="underline hover:text-[#569b6f] transition-colors"
-                >
-                  Rust
-                </a>
-                , which allows it to leverage the language's speed and efficiency
-                for faster builds and more responsive development experiences
-              </p>
+              <div className="ml-auto w-full max-w-none md:max-w-[600px] lg:max-w-[573px] [font-family:'Golos_Text',Helvetica] font-medium text-[#6b6b6b] text-lg md:text-xl lg:text-[25px] tracking-[0.3px] md:tracking-[0.4px] lg:tracking-[0.44px] leading-relaxed md:leading-[1.3] lg:leading-[31.8px] space-y-4">
+                <p>
+                  At Tempho, we believe finding a home should be simple, transparent, and stress-free. We connect you with high-quality, verified rental properties—offering flexible terms and tailored options to suit your needs.
+                </p>
+                <p>
+                  From modern condos to family townhouses, we combine local expertise with advanced tools to deliver an effortless rental experience.
+                </p>
+              </div>
             </div>
           </div>
         </section>
 
         {/* Services Section with Airbnb-Style Carousel */}
         <ServicesSection />
+
+        {/* Why Choose Tempho Section */}
+        <WhyChooseTempho />
+
+        {/* Call To Action Section */}
+        <CTASection />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- update hero, about, and services text
- add Why Choose Tempho and CTA sections
- create individual property listing detail pages and link cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f1462ce788326bd926a88992848b4