### PR TITLE
Update marketing content and add property detail pages

### DIFF
--- a/.screen-graph.json
+++ b/.screen-graph.json
@@ -15,9 +15,67 @@
       "routes": [
         "/listings"
       ]
+    },
+    {
+      "id": "src/pages/listings/500-halderfair-tower.tsx",
+      "label": "500-halderfair-tower",
+      "routes": [
+        "/listings/500-halderfair-tower"
+      ]
+    },
+    {
+      "id": "src/pages/listings/54-ferrinhill-street.tsx",
+      "label": "54-ferrinhill-street",
+      "routes": [
+        "/listings/54-ferrinhill-street"
+      ]
+    },
+    {
+      "id": "src/pages/listings/23-siennalane-hill.tsx",
+      "label": "23-siennalane-hill",
+      "routes": [
+        "/listings/23-siennalane-hill"
+      ]
+    },
+    {
+      "id": "src/pages/listings/789-maple-street.tsx",
+      "label": "789-maple-street",
+      "routes": [
+        "/listings/789-maple-street"
+      ]
+    },
+    {
+      "id": "src/pages/listings/456-oak-avenue.tsx",
+      "label": "456-oak-avenue",
+      "routes": [
+        "/listings/456-oak-avenue"
+      ]
+    },
+    {
+      "id": "src/pages/listings/123-pine-road.tsx",
+      "label": "123-pine-road",
+      "routes": [
+        "/listings/123-pine-road"
+      ]
     }
   ],
   "edges": [
+    {
+      "id": "src/components/CTASection.tsx:15:8-to-src/pages/listings.tsx",
+      "source": "src/screens/House/House.tsx",
+      "target": "src/pages/listings.tsx",
+      "data": {
+        "viaRoute": "/listings",
+        "trigger": {
+          "element": "<Link to=\"/listings\">\n          <Button className=\"bg-[#4CAF87] hover:bg-[#3b9b73] text-white text-lg md:text-xl px-8 py-4 rounded-full\">\n            Find Your Home\n          </Button>\n        </Link>",
+          "line": 15,
+          "endLine": 19,
+          "column": 8,
+          "endColumn": 15,
+          "sourceFile": "src/components/CTASection.tsx"
+        }
+      }
+    },
     {
       "id": "src/pages/listings.tsx:26:4-to-src/pages/listings.tsx",
       "source": "src/pages/listings.tsx",

--- a/src/components/AboutUs.tsx
+++ b/src/components/AboutUs.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Badge } from './ui/badge';
+
+const AboutUs: React.FC = () => {
+  return (
+    <section className="w-full bg-white">
+      <div className="container py-12 md:py-18 lg:py-24">
+        <div className="flex items-center mb-6 md:mb-8">
+          <div className="w-3 h-3 bg-[#569b6f] rounded-md mr-4 md:mr-6 lg:mr-[22px] flex-shrink-0" />
+          <Badge className="bg-transparent [font-family:'Golos_Text',Helvetica] font-semibold text-[#569b6f] text-base md:text-lg lg:text-xl tracking-[1.5px] md:tracking-[2px] lg:tracking-[2.60px] leading-[1.2] lg:leading-[21.1px] p-0">
+            ABOUT US
+          </Badge>
+        </div>
+
+        <div className="space-y-6 md:space-y-8">
+          <p className="w-full max-w-none lg:max-w-[1043px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-xl md:text-2xl lg:text-[40px] leading-relaxed md:leading-[1.3] lg:leading-10 tracking-[0]">
+            Your Gateway to Seamless Canadian Living
+          </p>
+
+          <p className="ml-auto w-full max-w-none md:max-w-[600px] lg:max-w-[573px] [font-family:'Golos_Text',Helvetica] font-medium text-[#6b6b6b] text-lg md:text-xl lg:text-[25px] tracking-[0.3px] md:tracking-[0.4px] lg:tracking-[0.44px] leading-relaxed md:leading-[1.3] lg:leading-[31.8px]">
+            At Tempho, we believe finding a home should be simple, transparent, and stress-free. We connect you with high-quality, verified rental properties—offering flexible terms and tailored options to suit your needs.
+            <br /><br />
+            From modern condos to family townhouses, we combine local expertise with advanced tools to deliver an effortless rental experience.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default AboutUs;

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Button } from './ui/button';
+import { Link } from 'react-router-dom';
+
+const CTASection: React.FC = () => {
+  return (
+    <section className="w-full bg-[#FFF7EB]">
+      <div className="container py-12 md:py-16 lg:py-20 text-center">
+        <h2 className="[font-family:'Golos_Text',Helvetica] font-medium text-black text-2xl md:text-3xl lg:text-4xl mb-4">
+          Start your journey today.
+        </h2>
+        <p className="[font-family:'Golos_Text',Helvetica] font-medium text-[#6b6b6b] text-lg md:text-xl lg:text-2xl mb-8">
+          Browse our growing collection of properties and secure your next home in Canada.
+        </p>
+        <Link to="/listings">
+          <Button className="bg-[#4CAF87] hover:bg-[#3b9b73] text-white text-lg md:text-xl px-8 py-4 rounded-full">
+            Find Your Home
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default CTASection;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -17,11 +17,11 @@ const HeroSection: React.FC = () => {
           {/* Hero Content */}
           <div className="flex-1 pt-16 md:pt-24 lg:pt-40 text-center lg:text-left">
             <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-4xl md:text-6xl lg:text-8xl tracking-[-2px] md:tracking-[-4px] lg:tracking-[-5.76px] leading-tight md:leading-[1.1] lg:leading-[84.3px] mb-6 md:mb-8 lg:mb-10">
-              Welcome To Your <br />
+              Welcome to Your <br />
               Canadian Dream
             </h1>
             <p className="w-full max-w-[400px] md:max-w-[500px] lg:max-w-[522px] mx-auto lg:mx-0 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-lg md:text-2xl lg:text-[32px] tracking-[-1px] md:tracking-[-1.5px] lg:tracking-[-1.92px] leading-relaxed md:leading-[1.2] lg:leading-[28.1px] mb-8 md:mb-10 lg:mb-12">
-              At the frontier of the living lavish lifestyle in Canada
+              Find your perfect home at the frontier of Canada’s lavish living. Whether you’re a newcomer, student, or simply seeking a fresh start, Tempho makes it easy to discover secure, stylish, and affordable furnished rentals—all in one place.
             </p>
 
             <Button
@@ -36,6 +36,9 @@ const HeroSection: React.FC = () => {
                 />
               </div>
             </Button>
+            <p className="mt-4 [font-family:'Golos_Text',Helvetica] font-medium text-[#6f6f6f] text-sm md:text-base lg:text-lg">
+              Trusted by many, with over CA$150K+ in revenue and growing.
+            </p>
           </div>
 
           {/* Hero Image Section - Hidden on mobile, visible on large screens */}

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent } from './ui/card';
 import { PropertyListing } from '../data/listings';
+import { Link } from 'react-router-dom';
 
 interface PropertyCardProps {
   property: PropertyListing;
@@ -8,8 +9,9 @@ interface PropertyCardProps {
 
 export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
   return (
-    <Card className="w-[280px] md:w-[320px] lg:w-[360px] h-auto bg-transparent border-none shadow-none flex-shrink-0 cursor-pointer group">
-      <CardContent className="p-0">
+    <Link to={`/listings/${property.slug}`} className="block">
+      <Card className="w-[280px] md:w-[320px] lg:w-[360px] h-auto bg-transparent border-none shadow-none flex-shrink-0 cursor-pointer group">
+        <CardContent className="p-0">
         {/* Property Image */}
         <div className="relative overflow-hidden rounded-xl mb-3">
           <img
@@ -43,8 +45,9 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
             {property.beds} Bed{property.beds !== 1 ? 's' : ''} | {property.baths} Bath{property.baths !== 1 ? 's' : ''} | {property.garage}-Car Garage
           </div>
         </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </Link>
   );
 };
 

--- a/src/components/WhyChooseTempho.tsx
+++ b/src/components/WhyChooseTempho.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ShieldCheck, CalendarClock, Users, Search } from 'lucide-react';
+import { Badge } from './ui/badge';
+
+const features = [
+  { icon: ShieldCheck, title: 'Verified & Safe', description: 'Every listing is vetted to ensure peace of mind.' },
+  { icon: CalendarClock, title: 'Flexible Terms', description: 'Options for monthly rentals and beyond.' },
+  { icon: Users, title: 'For Everyone', description: 'Perfect for newcomers, students, families, and professionals.' },
+  { icon: Search, title: 'Simple Search', description: 'Filter by location, budget, and amenities with ease.' },
+];
+
+const WhyChooseTempho: React.FC = () => {
+  return (
+    <section className="w-full bg-white">
+      <div className="container py-12 md:py-18 lg:py-24">
+        <div className="flex items-center mb-6 md:mb-8">
+          <div className="w-3 h-3 bg-[#569b6f] rounded-md mr-4 md:mr-6 lg:mr-[22px] flex-shrink-0" />
+          <Badge className="bg-transparent [font-family:'Golos_Text',Helvetica] font-semibold text-[#569b6f] text-base md:text-lg lg:text-xl tracking-[1.5px] md:tracking-[2px] lg:tracking-[2.60px] leading-[1.2] lg:leading-[21.1px] p-0">
+            WHY CHOOSE TEMPHO?
+          </Badge>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {features.map((feature, idx) => {
+            const Icon = feature.icon;
+            return (
+              <div key={idx} className="flex items-start space-x-4">
+                <Icon className="w-8 h-8 text-[#4CAF87] flex-shrink-0" />
+                <div className="[font-family:'Golos_Text',Helvetica]">
+                  <div className="font-semibold text-black text-lg md:text-xl mb-1">{feature.title}</div>
+                  <p className="text-[#6b6b6b] text-base md:text-lg leading-relaxed">{feature.description}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default WhyChooseTempho;

--- a/src/data/listings.ts
+++ b/src/data/listings.ts
@@ -1,5 +1,6 @@
 export interface PropertyListing {
   id: number;
+  slug: string;
   imageUrl: string;
   price: string;
   propertyType: string;
@@ -12,6 +13,7 @@ export interface PropertyListing {
 export const propertyListings: PropertyListing[] = [
   {
     id: 1,
+    slug: "500-halderfair-tower",
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-3.png",
     price: "CA$ 1500/month",
     propertyType: "Condominium",
@@ -22,6 +24,7 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 2,
+    slug: "54-ferrinhill-street",
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-4.png",
     price: "CA$ 1500/month",
     propertyType: "Apartment",
@@ -32,6 +35,7 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 3,
+    slug: "23-siennalane-hill",
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-5.png",
     price: "CA$ 1500/month",
     propertyType: "House",
@@ -42,6 +46,7 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 4,
+    slug: "789-maple-street",
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-3.png",
     price: "CA$ 1800/month",
     propertyType: "Townhouse",
@@ -52,6 +57,7 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 5,
+    slug: "456-oak-avenue",
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-4.png",
     price: "CA$ 2200/month",
     propertyType: "Detached House",
@@ -62,6 +68,7 @@ export const propertyListings: PropertyListing[] = [
   },
   {
     id: 6,
+    slug: "123-pine-road",
     imageUrl: "https://c.animaapp.com/mdww1mm3xpw4UO/img/mask-group-5.png",
     price: "CA$ 1200/month",
     propertyType: "Studio",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,12 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { House } from "./screens/House";
 import ListingsPage from "./pages/listings";
+import Halderfair from "./pages/listings/500-halderfair-tower";
+import Ferrinhill from "./pages/listings/54-ferrinhill-street";
+import Siennalane from "./pages/listings/23-siennalane-hill";
+import Maple from "./pages/listings/789-maple-street";
+import Oak from "./pages/listings/456-oak-avenue";
+import Pine from "./pages/listings/123-pine-road";
 
 createRoot(document.getElementById("app") as HTMLElement).render(
   <StrictMode>
@@ -10,6 +16,12 @@ createRoot(document.getElementById("app") as HTMLElement).render(
       <Routes>
         <Route path="/" element={<House />} />
         <Route path="/listings" element={<ListingsPage />} />
+        <Route path="/listings/500-halderfair-tower" element={<Halderfair />} />
+        <Route path="/listings/54-ferrinhill-street" element={<Ferrinhill />} />
+        <Route path="/listings/23-siennalane-hill" element={<Siennalane />} />
+        <Route path="/listings/789-maple-street" element={<Maple />} />
+        <Route path="/listings/456-oak-avenue" element={<Oak />} />
+        <Route path="/listings/123-pine-road" element={<Pine />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/src/pages/listings/123-pine-road.tsx
+++ b/src/pages/listings/123-pine-road.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetailTemplate from './PropertyDetailTemplate';
+
+const property = propertyListings.find(p => p.slug === '123-pine-road');
+
+export default function Page() {
+  if (!property) return null;
+  return <PropertyDetailTemplate property={property} />;
+}

--- a/src/pages/listings/23-siennalane-hill.tsx
+++ b/src/pages/listings/23-siennalane-hill.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetailTemplate from './PropertyDetailTemplate';
+
+const property = propertyListings.find(p => p.slug === '23-siennalane-hill');
+
+export default function Page() {
+  if (!property) return null;
+  return <PropertyDetailTemplate property={property} />;
+}

--- a/src/pages/listings/456-oak-avenue.tsx
+++ b/src/pages/listings/456-oak-avenue.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetailTemplate from './PropertyDetailTemplate';
+
+const property = propertyListings.find(p => p.slug === '456-oak-avenue');
+
+export default function Page() {
+  if (!property) return null;
+  return <PropertyDetailTemplate property={property} />;
+}

--- a/src/pages/listings/500-halderfair-tower.tsx
+++ b/src/pages/listings/500-halderfair-tower.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetailTemplate from './PropertyDetailTemplate';
+
+const property = propertyListings.find(p => p.slug === '500-halderfair-tower');
+
+export default function Page() {
+  if (!property) return null;
+  return <PropertyDetailTemplate property={property} />;
+}

--- a/src/pages/listings/54-ferrinhill-street.tsx
+++ b/src/pages/listings/54-ferrinhill-street.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetailTemplate from './PropertyDetailTemplate';
+
+const property = propertyListings.find(p => p.slug === '54-ferrinhill-street');
+
+export default function Page() {
+  if (!property) return null;
+  return <PropertyDetailTemplate property={property} />;
+}

--- a/src/pages/listings/789-maple-street.tsx
+++ b/src/pages/listings/789-maple-street.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { propertyListings } from '../../data/listings';
+import PropertyDetailTemplate from './PropertyDetailTemplate';
+
+const property = propertyListings.find(p => p.slug === '789-maple-street');
+
+export default function Page() {
+  if (!property) return null;
+  return <PropertyDetailTemplate property={property} />;
+}

--- a/src/pages/listings/PropertyDetailTemplate.tsx
+++ b/src/pages/listings/PropertyDetailTemplate.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Header from '../../components/Header';
+import { PropertyListing } from '../../data/listings';
+import { Button } from '../../components/ui/button';
+
+interface PropertyDetailTemplateProps {
+  property: PropertyListing;
+}
+
+const PropertyDetailTemplate: React.FC<PropertyDetailTemplateProps> = ({ property }) => {
+  return (
+    <main className="bg-white w-full min-h-screen">
+      <Header />
+      <section className="container py-8 md:py-12">
+        <img
+          src={property.imageUrl}
+          alt={property.address}
+          className="w-full h-64 md:h-96 object-cover rounded-xl mb-8"
+        />
+        <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-black text-3xl md:text-4xl lg:text-5xl mb-4">
+          {property.address}
+        </h1>
+        <p className="[font-family:'Golos_Text',Helvetica] text-[#6b6b6b] text-lg md:text-xl mb-2">
+          {property.price} — {property.propertyType}
+        </p>
+        <p className="[font-family:'Golos_Text',Helvetica] text-black text-base md:text-lg mb-6">
+          {property.beds} Bed{property.beds !== 1 ? 's' : ''} | {property.baths} Bath{property.baths !== 1 ? 's' : ''} | {property.garage}-Car Garage
+        </p>
+        <p className="[font-family:'Golos_Text',Helvetica] text-[#6b6b6b] text-base md:text-lg leading-relaxed mb-8">
+          This furnished property offers comfort and convenience in a prime Canadian location. Enjoy modern amenities, inviting interiors, and easy access to local attractions. Perfect for short- or long-term stays.
+        </p>
+        <Button className="bg-[#4CAF87] hover:bg-[#3b9b73] text-white text-lg px-6 py-3 rounded-full">
+          Contact / Book
+        </Button>
+      </section>
+    </main>
+  );
+};
+
+export default PropertyDetailTemplate;

--- a/src/screens/House/House.tsx
+++ b/src/screens/House/House.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { Badge } from "../../components/ui/badge";
 import { ServicesSection } from "../../components/ServicesSection";
 import Header from "../../components/Header";
 import HeroSection from "../../components/HeroSection";
+import AboutUs from "../../components/AboutUs";
+import WhyChooseTempho from "../../components/WhyChooseTempho";
+import CTASection from "../../components/CTASection";
 
 export const House = (): JSX.Element => {
   return (
@@ -14,51 +16,16 @@ export const House = (): JSX.Element => {
         {/* Hero Section */}
         <HeroSection />
 
-        {/* About Us Section */}
-        <section className="w-full bg-white">
-          <div className="container py-12 md:py-18 lg:py-24">
-            <div className="flex items-center mb-6 md:mb-8">
-              <div className="w-3 h-3 bg-[#569b6f] rounded-md mr-4 md:mr-6 lg:mr-[22px] flex-shrink-0" />
-              <Badge className="bg-transparent [font-family:'Golos_Text',Helvetica] font-semibold text-[#569b6f] text-base md:text-lg lg:text-xl tracking-[1.5px] md:tracking-[2px] lg:tracking-[2.60px] leading-[1.2] lg:leading-[21.1px] p-0">
-                ABOUT US
-              </Badge>
-            </div>
-
-            <div className="space-y-6 md:space-y-8">
-              <p className="w-full max-w-none lg:max-w-[1043px] [font-family:'Golos_Text',Helvetica] font-medium text-black text-xl md:text-2xl lg:text-[40px] leading-relaxed md:leading-[1.3] lg:leading-10 tracking-[0]">
-                Prevail in the subahs Turbo Pack is a new, high-performance bundler
-                designed to speed up development in Next.js. It's built by Vercel,
-                the creators of Next.js, and is intended to replace{" "}
-                <a
-                  href="https://www.google.com/search?sca_esv=12c7b01f52a29939&amp;rlz=1C1NDCM_enNG1030NG1030&amp;sxsrf=AE3TifNnBaIZBTcdMSmJJm3hmPwAzHy5qA%3A1753015930808&amp;q=Webpack&amp;sa=X&amp;ved=2ahUKEwi5sN2evcuOAxWSE1kFHbkcB-oQxccNegQIIxAB&amp;mstk=AUtExfBF0Z33ag7MkcoefjUTjtrCF9fF3FR54q6yJjlostu22nzvpJXZVV0LLqow4xrpnTvD_ung6IJfcq5f0THVaULczWVGKkNzYSin0Smr9nHwegWMhTR1O8XeetOqOGjAlrVyjMA86WiD8Lu_bxY5VfuyBdDV_tkHNPPR3vD8WCUn2VI&amp;csui=3"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  className="font-medium tracking-[0.5px] md:tracking-[0.8px] lg:tracking-[1.12px] leading-[1.3] lg:leading-[50.8px] underline hover:text-[#569b6f] transition-colors"
-                >
-                  Webpack
-                </a>{" "}
-                as the default bundler for Next.js applications.{" "}
-              </p>
-
-              <p className="ml-auto w-full max-w-none md:max-w-[600px] lg:max-w-[573px] [font-family:'Golos_Text',Helvetica] font-medium text-[#6b6b6b] text-lg md:text-xl lg:text-[25px] tracking-[0.3px] md:tracking-[0.4px] lg:tracking-[0.44px] leading-relaxed md:leading-[1.3] lg:leading-[31.8px]">
-                in{" "}
-                <a
-                  href="https://www.google.com/search?sca_esv=12c7b01f52a29939&amp;rlz=1C1NDCM_enNG1030NG1030&amp;sxsrf=AE3TifNnBaIZBTcdMSmJJm3hmPwAzHy5qA%3A1753015930808&amp;q=Rust&amp;sa=X&amp;ved=2ahUKEwi5sN2evcuOAxWSE1kFHbkcB-oQxccNegQINxAB&amp;mstk=AUtExfBF0Z33ag7MkcoefjUTjtrCF9fF3FR54q6yJjlostu22nzvpJXZVV0LLqow4xrpnTvD_ung6IJfcq5f0THVaULczWVGKkNzYSin0Smr9nHwegWMhTR1O8XeetOqOGjAlrVyjMA86WiD8Lu_bxY5VfuyBdDV_tkHNPPR3vD8WCUn2VI&amp;csui=3"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  className="underline hover:text-[#569b6f] transition-colors"
-                >
-                  Rust
-                </a>
-                , which allows it to leverage the language's speed and efficiency
-                for faster builds and more responsive development experiences
-              </p>
-            </div>
-          </div>
-        </section>
+        <AboutUs />
 
         {/* Services Section with Airbnb-Style Carousel */}
         <ServicesSection />
+
+        {/* Why Choose Tempho Section */}
+        <WhyChooseTempho />
+
+        {/* Call To Action Section */}
+        <CTASection />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Revise hero and about copy and add CTA messaging
- Add "Why Choose Tempho" and homepage CTA sections
- Link property cards to new listing detail pages with routing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f1462ce788326bd926a88992848b4