### PR TITLE
feat: hover image carousel for listings with lazy loading

### DIFF
--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -25,6 +25,24 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const { isMobile } = useResponsive();
 
+  const startAutoPlay = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    if (autoPlay && images.length > 1) {
+      intervalRef.current = setInterval(() => {
+        setCurrentIndex((prev) => (prev + 1) % images.length);
+      }, 1800);
+    }
+  };
+
+  const stopAutoPlay = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
   // Use mobile carousel on mobile devices
   if (isMobile) {
     return (
@@ -39,32 +57,29 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
 
   // Auto-play functionality
   useEffect(() => {
-    if (autoPlay && isHovered && images.length > 1) {
-      intervalRef.current = setInterval(() => {
-        setCurrentIndex((prev) => (prev + 1) % images.length);
-      }, 1800);
+    if (autoPlay && isHovered) {
+      startAutoPlay();
     } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
+      stopAutoPlay();
     }
 
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
-    };
+    return () => stopAutoPlay();
   }, [autoPlay, isHovered, images.length]);
 
   const goToPrevious = (e: React.MouseEvent) => {
     e.stopPropagation();
     setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
+    if (isHovered && autoPlay) {
+      startAutoPlay();
+    }
   };
 
   const goToNext = (e: React.MouseEvent) => {
     e.stopPropagation();
     setCurrentIndex((prev) => (prev + 1) % images.length);
+    if (isHovered && autoPlay) {
+      startAutoPlay();
+    }
   };
 
   const handleMouseEnter = () => {
@@ -73,6 +88,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
 
   const handleMouseLeave = () => {
     setIsHovered(false);
+    stopAutoPlay();
     setCurrentIndex(0); // Reset to first image
   };
 
@@ -85,6 +101,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
           alt={alt}
           className="w-full h-full object-cover cursor-pointer"
           onClick={onImageClick}
+          loading="lazy"
         />
       </div>
     );
@@ -107,6 +124,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
               index === currentIndex ? 'opacity-100' : 'opacity-0'
             }`}
             onClick={onImageClick}
+            loading="lazy"
           />
         ))}
       </div>

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -9,8 +9,8 @@ interface ListingCardProps {
 }
 
 export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, selected }) => {
-  // Convert single image to array for carousel compatibility
-  const images = listing.image ? [listing.image] : [];
+  // Use provided images array or fallback to single image
+  const images = listing.images && listing.images.length > 0 ? listing.images : listing.image ? [listing.image] : [];
   
   return (
     <div
@@ -21,8 +21,8 @@ export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, sele
         images={images}
         alt={listing.title}
         className="w-full h-48"
-        autoPlay={false}
-        showArrows={false}
+        autoPlay={images.length > 1}
+        showArrows={images.length > 1}
       />
       <div className="p-4 space-y-1">
         <h3 className="text-lg font-semibold text-[#4CAF87] [font-family:'Golos_Text',Helvetica]">

--- a/src/components/MobileImageCarousel.tsx
+++ b/src/components/MobileImageCarousel.tsx
@@ -80,6 +80,7 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
           alt={alt}
           className="w-full h-full object-cover cursor-pointer"
           onClick={onImageClick}
+          loading="lazy"
         />
       </div>
     );
@@ -106,6 +107,7 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
               alt={`${alt} - Image ${index + 1}`}
               className="w-full h-full object-cover cursor-pointer"
               onClick={onImageClick}
+              loading="lazy"
               draggable={false}
             />
           </div>

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -23,7 +23,7 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
               showArrows={true}
             />
             {/* Hover overlay */}
-            <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300" />
+            <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300 pointer-events-none" />
           </div>
 
           {/* Property Details */}

--- a/src/data/mockListings.ts
+++ b/src/data/mockListings.ts
@@ -1,3 +1,5 @@
+import { propertyListings } from './listings';
+
 export const mockListings = [
   {
     id: 1,
@@ -5,7 +7,8 @@ export const mockListings = [
     location: "Toronto, Canada",
     price: 1800,
     guests: 2,
-    image: "/images/listing1.jpg",
+    images: propertyListings[0].images,
+    image: propertyListings[0].images[0],
     coordinates: { lat: 43.6532, lng: -79.3832 }
   },
   {
@@ -14,7 +17,8 @@ export const mockListings = [
     location: "Vancouver, Canada",
     price: 1500,
     guests: 4,
-    image: "/images/listing2.jpg",
+    images: propertyListings[1].images,
+    image: propertyListings[1].images[0],
     coordinates: { lat: 49.2827, lng: -123.1207 }
   },
   {
@@ -23,7 +27,8 @@ export const mockListings = [
     location: "Montreal, Canada",
     price: 2500,
     guests: 5,
-    image: "/images/listing3.jpg",
+    images: propertyListings[2].images,
+    image: propertyListings[2].images[0],
     coordinates: { lat: 45.5017, lng: -73.5673 }
   },
   {
@@ -32,7 +37,8 @@ export const mockListings = [
     location: "Calgary, Canada",
     price: 1300,
     guests: 3,
-    image: "/images/listing4.jpg",
+    images: propertyListings[3].images,
+    image: propertyListings[3].images[0],
     coordinates: { lat: 51.0447, lng: -114.0719 }
   }
 ];

--- a/src/pages/listings/index.tsx
+++ b/src/pages/listings/index.tsx
@@ -7,23 +7,7 @@ import { mockListings } from '../../data/mockListings';
 import '../../styles/Listings.css';
 
 export const ListingsPage: React.FC = () => {
-  // Use mock listings with demo images
-  const demoListings = mockListings.map(listing => ({
-    ...listing,
-    image: `https://images.pexels.com/photos/${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }/pexels-photo-${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }.jpeg?auto=compress&cs=tinysrgb&w=800`
-  }));
-  
-  const listings = demoListings;
+  const listings = mockListings;
   const [selected, setSelected] = useState<number | null>(null);
   const [params, setParams] = useSearchParams();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- fix property card hover overlay so slideshow activates
- refactor image carousel with reusable hover autoplay, arrows and lazy loading
- enable hover slideshow on listings page using existing image sets

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5004abcc08326bab63a853d8b994a