### PR TITLE
Refactor image carousel with hover autoplay and lazy loading

### DIFF
--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -37,34 +37,39 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
     );
   }
 
-  // Auto-play functionality
-  useEffect(() => {
+  // Helpers to control autoplay interval
+  const stopAutoPlay = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  const startAutoPlay = () => {
     if (autoPlay && isHovered && images.length > 1) {
+      stopAutoPlay();
       intervalRef.current = setInterval(() => {
         setCurrentIndex((prev) => (prev + 1) % images.length);
       }, 1800);
-    } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
     }
+  };
 
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
-    };
+  // Auto-play functionality
+  useEffect(() => {
+    startAutoPlay();
+    return stopAutoPlay;
   }, [autoPlay, isHovered, images.length]);
 
   const goToPrevious = (e: React.MouseEvent) => {
     e.stopPropagation();
     setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
+    startAutoPlay();
   };
 
   const goToNext = (e: React.MouseEvent) => {
     e.stopPropagation();
     setCurrentIndex((prev) => (prev + 1) % images.length);
+    startAutoPlay();
   };
 
   const handleMouseEnter = () => {
@@ -83,6 +88,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
         <img
           src={images[0]}
           alt={alt}
+          loading="lazy"
           className="w-full h-full object-cover cursor-pointer"
           onClick={onImageClick}
         />
@@ -103,6 +109,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
             key={index}
             src={image}
             alt={`${alt} - Image ${index + 1}`}
+            loading="lazy"
             className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-300 cursor-pointer ${
               index === currentIndex ? 'opacity-100' : 'opacity-0'
             }`}

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -9,8 +9,8 @@ interface ListingCardProps {
 }
 
 export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, selected }) => {
-  // Convert single image to array for carousel compatibility
-  const images = listing.image ? [listing.image] : [];
+  // Use provided images array or fall back to single image
+  const images = listing.images && listing.images.length ? listing.images : listing.image ? [listing.image] : [];
   
   return (
     <div
@@ -21,8 +21,8 @@ export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, sele
         images={images}
         alt={listing.title}
         className="w-full h-48"
-        autoPlay={false}
-        showArrows={false}
+        autoPlay={images.length > 1}
+        showArrows={images.length > 1}
       />
       <div className="p-4 space-y-1">
         <h3 className="text-lg font-semibold text-[#4CAF87] [font-family:'Golos_Text',Helvetica]">

--- a/src/components/MobileImageCarousel.tsx
+++ b/src/components/MobileImageCarousel.tsx
@@ -78,6 +78,7 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
         <img
           src={images[0]}
           alt={alt}
+          loading="lazy"
           className="w-full h-full object-cover cursor-pointer"
           onClick={onImageClick}
         />
@@ -104,6 +105,7 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
             <img
               src={image}
               alt={`${alt} - Image ${index + 1}`}
+              loading="lazy"
               className="w-full h-full object-cover cursor-pointer"
               onClick={onImageClick}
               draggable={false}

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -19,11 +19,11 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
               images={property.images}
               alt={`${property.propertyType} at ${property.address}`}
               className="w-full h-[200px] md:h-[240px] lg:h-[280px]"
-              autoPlay={true}
-              showArrows={true}
+              autoPlay={property.images.length > 1}
+              showArrows={property.images.length > 1}
             />
             {/* Hover overlay */}
-            <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300" />
+            <div className="pointer-events-none absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300" />
           </div>
 
           {/* Property Details */}

--- a/src/data/mockListings.ts
+++ b/src/data/mockListings.ts
@@ -1,11 +1,24 @@
-export const mockListings = [
+import { propertyListings } from './listings';
+
+export interface Listing {
+  id: number;
+  title: string;
+  location: string;
+  price: number;
+  guests: number;
+  images: string[];
+  image?: string;
+  coordinates: { lat: number; lng: number };
+}
+
+export const mockListings: Listing[] = [
   {
     id: 1,
     title: "Modern Condo in Downtown Toronto",
     location: "Toronto, Canada",
     price: 1800,
     guests: 2,
-    image: "/images/listing1.jpg",
+    images: propertyListings[0].images,
     coordinates: { lat: 43.6532, lng: -79.3832 }
   },
   {
@@ -14,7 +27,7 @@ export const mockListings = [
     location: "Vancouver, Canada",
     price: 1500,
     guests: 4,
-    image: "/images/listing2.jpg",
+    images: propertyListings[1].images,
     coordinates: { lat: 49.2827, lng: -123.1207 }
   },
   {
@@ -23,7 +36,7 @@ export const mockListings = [
     location: "Montreal, Canada",
     price: 2500,
     guests: 5,
-    image: "/images/listing3.jpg",
+    images: propertyListings[2].images,
     coordinates: { lat: 45.5017, lng: -73.5673 }
   },
   {
@@ -32,9 +45,8 @@ export const mockListings = [
     location: "Calgary, Canada",
     price: 1300,
     guests: 3,
-    image: "/images/listing4.jpg",
+    images: propertyListings[3].images,
     coordinates: { lat: 51.0447, lng: -114.0719 }
   }
 ];
 
-export type Listing = typeof mockListings[number];

--- a/src/pages/listings/index.tsx
+++ b/src/pages/listings/index.tsx
@@ -7,23 +7,7 @@ import { mockListings } from '../../data/mockListings';
 import '../../styles/Listings.css';
 
 export const ListingsPage: React.FC = () => {
-  // Use mock listings with demo images
-  const demoListings = mockListings.map(listing => ({
-    ...listing,
-    image: `https://images.pexels.com/photos/${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }/pexels-photo-${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }.jpeg?auto=compress&cs=tinysrgb&w=800`
-  }));
-  
-  const listings = demoListings;
+  const listings = mockListings;
   const [selected, setSelected] = useState<number | null>(null);
   const [params, setParams] = useSearchParams();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- add reusable image carousel with hover-triggered autoplay, arrows, and lazy-loaded images
- enable same carousel on listings page and fix overlay blocking hover
- source listing images from existing `listings.ts` data

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5004abcc08326bab63a853d8b994a