### PR TITLE
Refactor hover image carousel with lazy loading

### DIFF
--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useResponsive } from '../hooks/useResponsive';
 import MobileImageCarousel from './MobileImageCarousel';
@@ -37,17 +37,20 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
     );
   }
 
+  const startAutoPlay = useCallback(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    intervalRef.current = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % images.length);
+    }, 1800);
+  }, [images.length]);
+
   // Auto-play functionality
   useEffect(() => {
     if (autoPlay && isHovered && images.length > 1) {
-      intervalRef.current = setInterval(() => {
-        setCurrentIndex((prev) => (prev + 1) % images.length);
-      }, 1800);
-    } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
+      startAutoPlay();
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
     }
 
     return () => {
@@ -55,16 +58,18 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
         clearInterval(intervalRef.current);
       }
     };
-  }, [autoPlay, isHovered, images.length]);
+  }, [autoPlay, isHovered, images.length, startAutoPlay]);
 
   const goToPrevious = (e: React.MouseEvent) => {
     e.stopPropagation();
     setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
+    if (autoPlay && isHovered) startAutoPlay();
   };
 
   const goToNext = (e: React.MouseEvent) => {
     e.stopPropagation();
     setCurrentIndex((prev) => (prev + 1) % images.length);
+    if (autoPlay && isHovered) startAutoPlay();
   };
 
   const handleMouseEnter = () => {
@@ -85,6 +90,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
           alt={alt}
           className="w-full h-full object-cover cursor-pointer"
           onClick={onImageClick}
+          loading="lazy"
         />
       </div>
     );
@@ -107,6 +113,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
               index === currentIndex ? 'opacity-100' : 'opacity-0'
             }`}
             onClick={onImageClick}
+            loading="lazy"
           />
         ))}
       </div>

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import { Listing } from '../data/mockListings';
 import { ImageCarousel } from './ImageCarousel';
 
+interface ListingWithImages extends Listing {
+  images?: string[];
+}
+
 interface ListingCardProps {
-  listing: Listing;
+  listing: ListingWithImages;
   onClick?: () => void;
   selected?: boolean;
 }
 
 export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, selected }) => {
-  // Convert single image to array for carousel compatibility
-  const images = listing.image ? [listing.image] : [];
+  // Use provided images array or fallback to single image
+  const images = listing.images && listing.images.length > 0 ? listing.images : listing.image ? [listing.image] : [];
   
   return (
     <div
@@ -21,8 +25,8 @@ export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, sele
         images={images}
         alt={listing.title}
         className="w-full h-48"
-        autoPlay={false}
-        showArrows={false}
+        autoPlay={true}
+        showArrows={true}
       />
       <div className="p-4 space-y-1">
         <h3 className="text-lg font-semibold text-[#4CAF87] [font-family:'Golos_Text',Helvetica]">

--- a/src/components/MobileImageCarousel.tsx
+++ b/src/components/MobileImageCarousel.tsx
@@ -80,6 +80,7 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
           alt={alt}
           className="w-full h-full object-cover cursor-pointer"
           onClick={onImageClick}
+          loading="lazy"
         />
       </div>
     );
@@ -107,6 +108,7 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
               className="w-full h-full object-cover cursor-pointer"
               onClick={onImageClick}
               draggable={false}
+              loading="lazy"
             />
           </div>
         ))}

--- a/src/pages/listings/index.tsx
+++ b/src/pages/listings/index.tsx
@@ -4,26 +4,18 @@ import Header from '../../components/Header';
 import ListingCard from '../../components/ListingCard';
 import MapPanel from '../../components/MapPanel';
 import { mockListings } from '../../data/mockListings';
+import { propertyListings } from '../../data/listings';
 import '../../styles/Listings.css';
 
 export const ListingsPage: React.FC = () => {
-  // Use mock listings with demo images
-  const demoListings = mockListings.map(listing => ({
-    ...listing,
-    image: `https://images.pexels.com/photos/${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }/pexels-photo-${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }.jpeg?auto=compress&cs=tinysrgb&w=800`
-  }));
-  
-  const listings = demoListings;
+  // Merge mock listing data with property listing images
+  const listings = mockListings.map(listing => {
+    const property = propertyListings.find(p => p.id === listing.id);
+    return {
+      ...listing,
+      images: property ? property.images : [listing.image],
+    };
+  });
   const [selected, setSelected] = useState<number | null>(null);
   const [params, setParams] = useSearchParams();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- enhance reusable `ImageCarousel` with hover autoplay, manual navigation, and lazy-loaded images
- enable swipe-friendly `MobileImageCarousel` with lazy loading
- support hover carousels on listings page using property image sets

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5004abcc08326bab63a853d8b994a