### PR TITLE
Refactor hover image carousel with dot indicators

### DIFF
--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useResponsive } from '../hooks/useResponsive';
 import MobileImageCarousel from './MobileImageCarousel';
 
@@ -8,7 +7,6 @@ interface ImageCarouselProps {
   alt: string;
   className?: string;
   autoPlay?: boolean;
-  showArrows?: boolean;
   onImageClick?: () => void;
 }
 
@@ -17,7 +15,6 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
   alt,
   className = '',
   autoPlay = false,
-  showArrows = true,
   onImageClick
 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -37,17 +34,20 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
     );
   }
 
+  const startAutoPlay = useCallback(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    intervalRef.current = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % images.length);
+    }, 1800);
+  }, [images.length]);
+
   // Auto-play functionality
   useEffect(() => {
     if (autoPlay && isHovered && images.length > 1) {
-      intervalRef.current = setInterval(() => {
-        setCurrentIndex((prev) => (prev + 1) % images.length);
-      }, 1800);
-    } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
+      startAutoPlay();
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
     }
 
     return () => {
@@ -55,16 +55,13 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
         clearInterval(intervalRef.current);
       }
     };
-  }, [autoPlay, isHovered, images.length]);
+  }, [autoPlay, isHovered, images.length, startAutoPlay]);
 
-  const goToPrevious = (e: React.MouseEvent) => {
+  const handleDotClick = (index: number, e: React.MouseEvent) => {
+    e.preventDefault();
     e.stopPropagation();
-    setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
-  };
-
-  const goToNext = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setCurrentIndex((prev) => (prev + 1) % images.length);
+    setCurrentIndex(index);
+    if (autoPlay && isHovered) startAutoPlay();
   };
 
   const handleMouseEnter = () => {
@@ -85,6 +82,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
           alt={alt}
           className="w-full h-full object-cover cursor-pointer"
           onClick={onImageClick}
+          loading="lazy"
         />
       </div>
     );
@@ -107,38 +105,20 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
               index === currentIndex ? 'opacity-100' : 'opacity-0'
             }`}
             onClick={onImageClick}
+            loading="lazy"
           />
         ))}
       </div>
 
-      {/* Navigation Arrows - Desktop only */}
-      {showArrows && images.length > 1 && (
-        <>
-          <button
-            onClick={goToPrevious}
-            className="absolute left-2 top-1/2 -translate-y-1/2 w-8 h-8 bg-white/90 hover:bg-white rounded-full shadow-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center z-10 hidden md:flex"
-            aria-label="Previous image"
-          >
-            <ChevronLeft className="w-4 h-4 text-[#4CAF87]" />
-          </button>
-          <button
-            onClick={goToNext}
-            className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 bg-white/90 hover:bg-white rounded-full shadow-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center z-10 hidden md:flex"
-            aria-label="Next image"
-          >
-            <ChevronRight className="w-4 h-4 text-[#4CAF87]" />
-          </button>
-        </>
-      )}
-
       {/* Image Indicators */}
       {images.length > 1 && (
-        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex space-x-1 z-10">
+        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex space-x-2 z-10 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
           {images.map((_, index) => (
-            <div
+            <button
               key={index}
-              className={`w-1.5 h-1.5 rounded-full transition-colors duration-200 ${
-                index === currentIndex ? 'bg-white' : 'bg-white/50'
+              onClick={(e) => handleDotClick(index, e)}
+              className={`w-2 h-2 rounded-full focus:outline-none transition-colors duration-200 ${
+                index === currentIndex ? 'bg-[#4CAF87]' : 'bg-gray-300'
               }`}
             />
           ))}

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import { Listing } from '../data/mockListings';
 import { ImageCarousel } from './ImageCarousel';
 
+interface ListingWithImages extends Listing {
+  images?: string[];
+}
+
 interface ListingCardProps {
-  listing: Listing;
+  listing: ListingWithImages;
   onClick?: () => void;
   selected?: boolean;
 }
 
 export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, selected }) => {
-  // Convert single image to array for carousel compatibility
-  const images = listing.image ? [listing.image] : [];
+  // Use provided images array or fallback to single image
+  const images = listing.images && listing.images.length > 0 ? listing.images : listing.image ? [listing.image] : [];
   
   return (
     <div
@@ -21,8 +25,7 @@ export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, sele
         images={images}
         alt={listing.title}
         className="w-full h-48"
-        autoPlay={false}
-        showArrows={false}
+        autoPlay={true}
       />
       <div className="p-4 space-y-1">
         <h3 className="text-lg font-semibold text-[#4CAF87] [font-family:'Golos_Text',Helvetica]">

--- a/src/components/MobileImageCarousel.tsx
+++ b/src/components/MobileImageCarousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 
 interface MobileImageCarouselProps {
   images: string[];
@@ -17,12 +17,14 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
   const [isDragging, setIsDragging] = useState(false);
   const [startX, setStartX] = useState(0);
   const [scrollLeft, setScrollLeft] = useState(0);
+  const [showIndicators, setShowIndicators] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Touch/swipe handling
   const handleTouchStart = (e: React.TouchEvent) => {
     setIsDragging(true);
     setStartX(e.touches[0].clientX);
+    setShowIndicators(true);
   };
 
   const handleTouchMove = (e: React.TouchEvent) => {
@@ -45,12 +47,14 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
         setCurrentIndex(currentIndex - 1);
       }
     }
+    setTimeout(() => setShowIndicators(false), 1500);
   };
 
   // Mouse handling for desktop
   const handleMouseDown = (e: React.MouseEvent) => {
     setIsDragging(true);
     setStartX(e.clientX);
+    setShowIndicators(true);
     if (containerRef.current) {
       setScrollLeft(containerRef.current.scrollLeft);
     }
@@ -66,10 +70,12 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
 
   const handleMouseUp = () => {
     setIsDragging(false);
+    setTimeout(() => setShowIndicators(false), 1500);
   };
 
   const handleMouseLeave = () => {
     setIsDragging(false);
+    setTimeout(() => setShowIndicators(false), 1500);
   };
 
   if (images.length <= 1) {
@@ -80,6 +86,7 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
           alt={alt}
           className="w-full h-full object-cover cursor-pointer"
           onClick={onImageClick}
+          loading="lazy"
         />
       </div>
     );
@@ -107,18 +114,29 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
               className="w-full h-full object-cover cursor-pointer"
               onClick={onImageClick}
               draggable={false}
+              loading="lazy"
             />
           </div>
         ))}
       </div>
 
       {/* Image Indicators */}
-      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex space-x-1 z-10">
+      <div
+        className={`absolute bottom-2 left-1/2 -translate-x-1/2 flex space-x-2 z-10 transition-opacity duration-300 ${
+          showIndicators ? 'opacity-100' : 'opacity-0'
+        }`}
+      >
         {images.map((_, index) => (
-          <div
+          <button
             key={index}
-            className={`w-1.5 h-1.5 rounded-full transition-colors duration-200 ${
-              index === currentIndex ? 'bg-white' : 'bg-white/50'
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setCurrentIndex(index);
+              setShowIndicators(true);
+            }}
+            className={`w-2 h-2 rounded-full focus:outline-none transition-colors duration-200 ${
+              index === currentIndex ? 'bg-[#4CAF87]' : 'bg-gray-300'
             }`}
           />
         ))}

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -20,7 +20,6 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
               alt={`${property.propertyType} at ${property.address}`}
               className="w-full h-[200px] md:h-[240px] lg:h-[280px]"
               autoPlay={true}
-              showArrows={true}
             />
             {/* Hover overlay */}
             <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300" />

--- a/src/pages/listings/index.tsx
+++ b/src/pages/listings/index.tsx
@@ -4,26 +4,18 @@ import Header from '../../components/Header';
 import ListingCard from '../../components/ListingCard';
 import MapPanel from '../../components/MapPanel';
 import { mockListings } from '../../data/mockListings';
+import { propertyListings } from '../../data/listings';
 import '../../styles/Listings.css';
 
 export const ListingsPage: React.FC = () => {
-  // Use mock listings with demo images
-  const demoListings = mockListings.map(listing => ({
-    ...listing,
-    image: `https://images.pexels.com/photos/${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }/pexels-photo-${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }.jpeg?auto=compress&cs=tinysrgb&w=800`
-  }));
-  
-  const listings = demoListings;
+  // Merge mock listing data with property listing images
+  const listings = mockListings.map(listing => {
+    const property = propertyListings.find(p => p.id === listing.id);
+    return {
+      ...listing,
+      images: property ? property.images : [listing.image],
+    };
+  });
   const [selected, setSelected] = useState<number | null>(null);
   const [params, setParams] = useSearchParams();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- replace arrow navigation with hover-revealed dot indicators that allow direct image selection
- show touch-activated dot indicators in mobile carousel for swipe navigation
- update property and listing cards to use the new dot-only carousel

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5004abcc08326bab63a853d8b994a