### PR TITLE
Restore hover autoplay and expand homepage listings

### DIFF
--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -2,28 +2,31 @@ import React from 'react';
 import { Listing } from '../data/mockListings';
 import { ImageCarousel } from './ImageCarousel';
 
+interface ListingWithImages extends Listing {
+  images?: string[];
+}
+
 interface ListingCardProps {
-  listing: Listing;
+  listing: ListingWithImages;
   onClick?: () => void;
   selected?: boolean;
 }
 
 export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, selected }) => {
-  // Convert single image to array for carousel compatibility
-  const images = listing.image ? [listing.image] : [];
+  // Use provided images array or fallback to single image
+  const images = listing.images && listing.images.length > 0 ? listing.images : listing.image ? [listing.image] : [];
   
   return (
     <div
       onClick={onClick}
       className={`cursor-pointer rounded-lg overflow-hidden shadow-md bg-white transition transform hover:scale-105 border-2 ${selected ? 'border-[#4CAF87]' : 'border-transparent'}`}
     >
-      <ImageCarousel
-        images={images}
-        alt={listing.title}
-        className="w-full h-48"
-        autoPlay={false}
-        showArrows={false}
-      />
+        <ImageCarousel
+          images={images}
+          alt={listing.title}
+          className="w-full h-48"
+          autoPlay={true}
+        />
       <div className="p-4 space-y-1">
         <h3 className="text-lg font-semibold text-[#4CAF87] [font-family:'Golos_Text',Helvetica]">
           {listing.title}

--- a/src/components/MobileImageCarousel.tsx
+++ b/src/components/MobileImageCarousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 
 interface MobileImageCarouselProps {
   images: string[];
@@ -18,11 +18,15 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
   const [startX, setStartX] = useState(0);
   const [scrollLeft, setScrollLeft] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [showDots, setShowDots] = useState(false);
+  const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Touch/swipe handling
   const handleTouchStart = (e: React.TouchEvent) => {
     setIsDragging(true);
     setStartX(e.touches[0].clientX);
+    setShowDots(true);
+    if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
   };
 
   const handleTouchMove = (e: React.TouchEvent) => {
@@ -33,6 +37,7 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
   const handleTouchEnd = (e: React.TouchEvent) => {
     if (!isDragging) return;
     setIsDragging(false);
+    hideTimeoutRef.current = setTimeout(() => setShowDots(false), 2000);
     
     const endX = e.changedTouches[0].clientX;
     const diffX = startX - endX;
@@ -51,9 +56,11 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
   const handleMouseDown = (e: React.MouseEvent) => {
     setIsDragging(true);
     setStartX(e.clientX);
+    setShowDots(true);
     if (containerRef.current) {
       setScrollLeft(containerRef.current.scrollLeft);
     }
+    if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {
@@ -66,10 +73,12 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
 
   const handleMouseUp = () => {
     setIsDragging(false);
+    hideTimeoutRef.current = setTimeout(() => setShowDots(false), 2000);
   };
 
   const handleMouseLeave = () => {
     setIsDragging(false);
+    hideTimeoutRef.current = setTimeout(() => setShowDots(false), 2000);
   };
 
   if (images.length <= 1) {
@@ -80,6 +89,7 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
           alt={alt}
           className="w-full h-full object-cover cursor-pointer"
           onClick={onImageClick}
+          loading="lazy"
         />
       </div>
     );
@@ -107,19 +117,29 @@ export const MobileImageCarousel: React.FC<MobileImageCarouselProps> = ({
               className="w-full h-full object-cover cursor-pointer"
               onClick={onImageClick}
               draggable={false}
+              loading="lazy"
             />
           </div>
         ))}
       </div>
 
-      {/* Image Indicators */}
-      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex space-x-1 z-10">
+      {/* Dot Indicators */}
+      <div
+        className={`absolute bottom-2 left-1/2 -translate-x-1/2 flex space-x-1 z-10 transition-opacity duration-200 ${
+          showDots ? 'opacity-100' : 'opacity-0'
+        }`}
+      >
         {images.map((_, index) => (
-          <div
+          <button
             key={index}
-            className={`w-1.5 h-1.5 rounded-full transition-colors duration-200 ${
-              index === currentIndex ? 'bg-white' : 'bg-white/50'
+            onClick={(e) => {
+              e.stopPropagation();
+              setCurrentIndex(index);
+            }}
+            className={`w-2 h-2 rounded-full transition-colors duration-200 ${
+              index === currentIndex ? 'bg-[#4CAF87]' : 'bg-gray-300'
             }`}
+            aria-label={`Go to image ${index + 1}`}
           />
         ))}
       </div>

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -20,7 +20,6 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
               alt={`${property.propertyType} at ${property.address}`}
               className="w-full h-[200px] md:h-[240px] lg:h-[280px]"
               autoPlay={true}
-              showArrows={true}
             />
             {/* Hover overlay */}
             <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300" />

--- a/src/data/listings.ts
+++ b/src/data/listings.ts
@@ -109,16 +109,114 @@ export const propertyListings: PropertyListing[] = [
     baths: 1,
     garage: 1,
   },
+  {
+    id: 7,
+    slug: '500-halderfair-tower',
+    images: [
+      "https://images.pexels.com/photos/1396122/pexels-photo-1396122.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1396132/pexels-photo-1396132.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1396125/pexels-photo-1396125.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1396129/pexels-photo-1396129.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1396135/pexels-photo-1396135.jpeg?auto=compress&cs=tinysrgb&w=800"
+    ],
+    price: "CA$1500/month",
+    propertyType: "Condominium",
+    address: "500 Halderfair Tower",
+    beds: 2,
+    baths: 2,
+    garage: 1,
+  },
+  {
+    id: 8,
+    slug: '54-ferrinhill-street',
+    images: [
+      "https://images.pexels.com/photos/1571460/pexels-photo-1571460.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1571463/pexels-photo-1571463.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1571468/pexels-photo-1571468.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1571471/pexels-photo-1571471.jpeg?auto=compress&cs=tinysrgb&w=800"
+    ],
+    price: "CA$1500/month",
+    propertyType: "Apartment",
+    address: "54 Ferrinhill Street",
+    beds: 2,
+    baths: 2,
+    garage: 1,
+  },
+  {
+    id: 9,
+    slug: '23-siennalane-hill',
+    images: [
+      "https://images.pexels.com/photos/1643383/pexels-photo-1643383.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1643384/pexels-photo-1643384.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1643389/pexels-photo-1643389.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1643395/pexels-photo-1643395.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1643401/pexels-photo-1643401.jpeg?auto=compress&cs=tinysrgb&w=800"
+    ],
+    price: "CA$1500/month",
+    propertyType: "House",
+    address: "23 Siennalane Hill",
+    beds: 3,
+    baths: 2,
+    garage: 1,
+  },
+  {
+    id: 10,
+    slug: '789-maple-street',
+    images: [
+      "https://images.pexels.com/photos/1732414/pexels-photo-1732414.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1732417/pexels-photo-1732417.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1732421/pexels-photo-1732421.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1732424/pexels-photo-1732424.jpeg?auto=compress&cs=tinysrgb&w=800"
+    ],
+    price: "CA$1800/month",
+    propertyType: "Townhouse",
+    address: "789 Maple Street",
+    beds: 3,
+    baths: 2,
+    garage: 2,
+  },
+  {
+    id: 11,
+    slug: '456-oak-avenue',
+    images: [
+      "https://images.pexels.com/photos/1918291/pexels-photo-1918291.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1918294/pexels-photo-1918294.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1918299/pexels-photo-1918299.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1918304/pexels-photo-1918304.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1918309/pexels-photo-1918309.jpeg?auto=compress&cs=tinysrgb&w=800"
+    ],
+    price: "CA$2200/month",
+    propertyType: "Detached House",
+    address: "456 Oak Avenue",
+    beds: 4,
+    baths: 3,
+    garage: 2,
+  },
+  {
+    id: 12,
+    slug: '123-pine-road',
+    images: [
+      "https://images.pexels.com/photos/2121121/pexels-photo-2121121.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/2121131/pexels-photo-2121131.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/2121141/pexels-photo-2121141.jpeg?auto=compress&cs=tinysrgb&w=800"
+    ],
+    price: "CA$1200/month",
+    propertyType: "Studio",
+    address: "123 Pine Road",
+    beds: 1,
+    baths: 1,
+    garage: 1,
+  },
 ];
 
 // Group listings by category for carousel display
 export const listingCategories = [
   {
     title: "Featured Properties",
-    listings: propertyListings.slice(0, 3),
+    listings: propertyListings.slice(0, 6),
   },
   {
     title: "New Listings",
-    listings: propertyListings.slice(3, 6),
+    listings: propertyListings.slice(6),
   },
 ];

--- a/src/pages/listings/index.tsx
+++ b/src/pages/listings/index.tsx
@@ -4,26 +4,18 @@ import Header from '../../components/Header';
 import ListingCard from '../../components/ListingCard';
 import MapPanel from '../../components/MapPanel';
 import { mockListings } from '../../data/mockListings';
+import { propertyListings } from '../../data/listings';
 import '../../styles/Listings.css';
 
 export const ListingsPage: React.FC = () => {
-  // Use mock listings with demo images
-  const demoListings = mockListings.map(listing => ({
-    ...listing,
-    image: `https://images.pexels.com/photos/${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }/pexels-photo-${
-      listing.id === 1 ? '1396122' : 
-      listing.id === 2 ? '1396132' : 
-      listing.id === 3 ? '1396125' : 
-      '1396129'
-    }.jpeg?auto=compress&cs=tinysrgb&w=800`
-  }));
-  
-  const listings = demoListings;
+  // Merge mock listing data with property listing images
+  const listings = mockListings.map(listing => {
+    const property = propertyListings.find(p => p.id === listing.id);
+    return {
+      ...listing,
+      images: property ? property.images : [listing.image],
+    };
+  });
   const [selected, setSelected] = useState<number | null>(null);
   const [params, setParams] = useSearchParams();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- restore hover-triggered autoplay in image carousel while keeping dot navigation
- add duplicated property listings to populate homepage horizontal scroll

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5004abcc08326bab63a853d8b994a