### PR TITLE
Add interactive maps and listing detail modal

### DIFF
--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -30,7 +30,7 @@ export const ListingCard: React.FC<ListingCardProps> = ({ listing, onClick, sele
         alt={listing.title}
         className="w-full h-48"
         autoPlay={images.length > 1}
-        showArrows={images.length > 1}
+        showArrows={false}
       />
       <div className="p-4 space-y-1">
         <h3 className="text-lg font-semibold text-[#4CAF87] [font-family:'Golos_Text',Helvetica]">

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+const icon = new L.Icon({
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+});
+
+interface MapProps {
+  coordinates: { lat: number; lng: number };
+  title: string;
+  price: string;
+  className?: string;
+  zoom?: number;
+}
+
+const Map: React.FC<MapProps> = ({ coordinates, title, price, className = 'w-full h-64', zoom = 13 }) => {
+  const position: [number, number] = [coordinates.lat, coordinates.lng];
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  return (
+    <div className={`relative ${className}`}>
+      {error && (
+        <div className="absolute inset-0 flex items-center justify-center bg-white text-center text-sm z-10">
+          ⚠️ Map failed to load. Please try reloading the page.
+        </div>
+      )}
+      <div
+        className={`absolute inset-0 flex items-center justify-center bg-white/60 z-10 transition-opacity duration-300 ${
+          loading && !error ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+      >
+        <div className="w-8 h-8 border-4 border-[#4CAF87] border-t-transparent rounded-full animate-spin" />
+      </div>
+      {!error && (
+        <MapContainer
+          center={position}
+          zoom={zoom}
+          className="w-full h-full"
+          scrollWheelZoom
+          whenReady={() => setLoading(false)}
+        >
+          <TileLayer
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            eventHandlers={{ tileerror: () => setError(true) }}
+          />
+          <Marker position={position} icon={icon}>
+            <Popup>
+              <div className="text-center">
+                <div className="font-semibold">{title}</div>
+                <div className="text-sm text-gray-600">{price}</div>
+              </div>
+            </Popup>
+          </Marker>
+        </MapContainer>
+      )}
+    </div>
+  );
+};
+
+export default Map;

--- a/src/components/MapPanel.tsx
+++ b/src/components/MapPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { MapContainer, TileLayer, Marker, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import { Listing } from '../data/mockListings';
 import 'leaflet/dist/leaflet.css';
@@ -48,7 +48,14 @@ export const MapPanel: React.FC<MapPanelProps> = ({ listings, selectedId, onSele
           position={[l.coordinates.lat, l.coordinates.lng] as any}
           icon={selectedId === l.id ? activeIcon : defaultIcon}
           eventHandlers={{ click: () => onSelect(l.id) }}
-        />
+        >
+          <Popup>
+            <div className="text-center [font-family:'Golos_Text',Helvetica]">
+              <div className="font-semibold">{l.title}</div>
+              <div className="text-sm text-gray-600">CA${l.price}/month</div>
+            </div>
+          </Popup>
+        </Marker>
       ))}
     </MapContainer>
   );

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -10,7 +10,7 @@ interface PropertyCardProps {
 
 export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
   return (
-    <Link to={`/listings/${property.slug}`} className="block">
+    <Link to={`/listing/${property.id}`} className="block">
       <Card className="w-[280px] md:w-[320px] lg:w-[360px] h-auto bg-transparent border-none shadow-none flex-shrink-0 cursor-pointer group">
         <CardContent className="p-0">
           {/* Property Image */}
@@ -20,7 +20,7 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
               alt={`${property.propertyType} at ${property.address}`}
               className="w-full h-[200px] md:h-[240px] lg:h-[280px]"
               autoPlay={true}
-              showArrows={true}
+              showArrows={false}
             />
             {/* Hover overlay */}
             <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300 pointer-events-none" />

--- a/src/data/listings.ts
+++ b/src/data/listings.ts
@@ -8,6 +8,7 @@ export interface PropertyListing {
   beds: number;
   baths: number;
   garage: number;
+  coordinates: { lat: number; lng: number };
 }
 
 export const propertyListings: PropertyListing[] = [
@@ -27,6 +28,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 2,
     baths: 2,
     garage: 1,
+    coordinates: { lat: 43.6532, lng: -79.3832 },
   },
   {
     id: 2,
@@ -43,6 +45,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 2,
     baths: 2,
     garage: 1,
+    coordinates: { lat: 49.2827, lng: -123.1207 },
   },
   {
     id: 3,
@@ -60,6 +63,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 3,
     baths: 2,
     garage: 1,
+    coordinates: { lat: 45.5017, lng: -73.5673 },
   },
   {
     id: 4,
@@ -76,6 +80,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 3,
     baths: 2,
     garage: 2,
+    coordinates: { lat: 51.0447, lng: -114.0719 },
   },
   {
     id: 5,
@@ -92,6 +97,7 @@ export const propertyListings: PropertyListing[] = [
     beds: 4,
     baths: 3,
     garage: 2,
+    coordinates: { lat: 45.4215, lng: -75.6972 },
   },
   {
     id: 6,
@@ -107,6 +113,39 @@ export const propertyListings: PropertyListing[] = [
     beds: 1,
     baths: 1,
     garage: 1,
+    coordinates: { lat: 53.5461, lng: -113.4938 },
+  },
+  {
+    id: 7,
+    slug: '88-lakeview-drive',
+    images: [
+      "https://images.pexels.com/photos/1396122/pexels-photo-1396122.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1396129/pexels-photo-1396129.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1396135/pexels-photo-1396135.jpeg?auto=compress&cs=tinysrgb&w=800"
+    ],
+    price: "CA$1700/month",
+    propertyType: "Condominium",
+    address: "88 Lakeview Drive",
+    beds: 2,
+    baths: 1,
+    garage: 1,
+    coordinates: { lat: 44.2312, lng: -76.4860 },
+  },
+  {
+    id: 8,
+    slug: '102-riverview-avenue',
+    images: [
+      "https://images.pexels.com/photos/1571460/pexels-photo-1571460.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1571463/pexels-photo-1571463.jpeg?auto=compress&cs=tinysrgb&w=800",
+      "https://images.pexels.com/photos/1571468/pexels-photo-1571468.jpeg?auto=compress&cs=tinysrgb&w=800"
+    ],
+    price: "CA$1600/month",
+    propertyType: "Apartment",
+    address: "102 Riverview Avenue",
+    beds: 2,
+    baths: 1,
+    garage: 1,
+    coordinates: { lat: 52.2681, lng: -113.8112 },
   },
 ];
 
@@ -114,10 +153,10 @@ export const propertyListings: PropertyListing[] = [
 export const listingCategories = [
   {
     title: "Featured Properties",
-    listings: propertyListings.slice(0, 3),
+    listings: propertyListings.slice(0, 4),
   },
   {
     title: "New Listings",
-    listings: propertyListings.slice(3, 6),
+    listings: propertyListings.slice(4, 8),
   },
 ];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,12 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { House } from "./screens/House";
 import ListingsPage from "./pages/listings";
-import Listing500HalderfairTower from "./pages/listings/500-halderfair-tower";
-import Listing54FerrinhillStreet from "./pages/listings/54-ferrinhill-street";
-import Listing23SiennalaneHill from "./pages/listings/23-siennalane-hill";
-import Listing789MapleStreet from "./pages/listings/789-maple-street";
-import Listing456OakAvenue from "./pages/listings/456-oak-avenue";
-import Listing123PineRoad from "./pages/listings/123-pine-road";
+import ListingDetail from "./pages/ListingDetail";
 
 createRoot(document.getElementById("app") as HTMLElement).render(
   <StrictMode>
@@ -16,12 +11,7 @@ createRoot(document.getElementById("app") as HTMLElement).render(
       <Routes>
         <Route path="/" element={<House />} />
         <Route path="/listings" element={<ListingsPage />} />
-        <Route path="/listings/500-halderfair-tower" element={<Listing500HalderfairTower />} />
-        <Route path="/listings/54-ferrinhill-street" element={<Listing54FerrinhillStreet />} />
-        <Route path="/listings/23-siennalane-hill" element={<Listing23SiennalaneHill />} />
-        <Route path="/listings/789-maple-street" element={<Listing789MapleStreet />} />
-        <Route path="/listings/456-oak-avenue" element={<Listing456OakAvenue />} />
-        <Route path="/listings/123-pine-road" element={<Listing123PineRoad />} />
+        <Route path="/listing/:id" element={<ListingDetail />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -1,0 +1,123 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import Header from '../components/Header';
+import PropertyGallery from '../components/PropertyGallery';
+import { propertyListings } from '../data/listings';
+import Map from '../components/Map';
+import { Maximize2, Minimize2 } from 'lucide-react';
+
+const ListingDetail: React.FC = () => {
+  const { id } = useParams();
+  const property = propertyListings.find((p) => p.id === Number(id));
+  const [showMap, setShowMap] = useState(false);
+  const [animate, setAnimate] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    if (showMap) {
+      document.body.style.overflow = 'hidden';
+      const handleKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') closeModal();
+      };
+      window.addEventListener('keydown', handleKey);
+      return () => window.removeEventListener('keydown', handleKey);
+    } else {
+      document.body.style.overflow = '';
+    }
+  }, [showMap]);
+
+  if (!property) return null;
+
+  const openModal = () => {
+    setShowMap(true);
+    setFullscreen(false);
+    requestAnimationFrame(() => setAnimate(true));
+  };
+
+  const closeModal = () => {
+    setAnimate(false);
+    setTimeout(() => {
+      setShowMap(false);
+      setFullscreen(false);
+    }, 300);
+  };
+
+  return (
+    <div className="bg-[#FFF7EB] min-h-screen">
+      <Header />
+      <div className="container pt-28 pb-16">
+        <PropertyGallery
+          images={property.images}
+          alt={`${property.propertyType} at ${property.address}`}
+          className="mb-8"
+        />
+        <h1 className="[font-family:'Golos_Text',Helvetica] font-semibold text-3xl md:text-4xl text-black mb-2">
+          {property.address}
+        </h1>
+        <p className="[font-family:'Golos_Text',Helvetica] text-xl md:text-2xl text-[#4CAF87] mb-4">
+          {property.price} — {property.propertyType}
+        </p>
+        <p className="[font-family:'Golos_Text',Helvetica] text-black text-lg mb-4">
+          {property.beds} Beds | {property.baths} Baths | {property.garage}-Car Garage
+        </p>
+        <p className="text-[#6b6b6b] mb-6">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at magna non nunc tristique rhoncus. Donec non semper nulla. Praesent vitae arcu tempor neque lacinia pretium. Proin viverra, ligula sit amet ultrices semper, ligula arcu tristique sapien, a accumsan nisi mauris ac eros.
+        </p>
+        {!showMap && (
+          <Map
+            coordinates={property.coordinates}
+            title={property.address}
+            price={property.price}
+            className="w-full h-64 rounded"
+          />
+        )}
+        <button
+          onClick={openModal}
+          className="mt-4 px-4 py-2 bg-[#4CAF87] text-white rounded [font-family:'Golos_Text',Helvetica]"
+        >
+          View on Map
+        </button>
+      </div>
+
+      {showMap && (
+        <div
+          className={`fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-300 ${
+            animate ? 'opacity-100' : 'opacity-0'
+          }`}
+          onClick={closeModal}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className={`relative ${fullscreen ? 'w-full h-full opacity-100 translate-y-0' : 'w-11/12 h-5/6 opacity-95 translate-y-2'} transition-all duration-300 ease-in-out transform ${
+              animate ? 'opacity-100' : 'opacity-0'
+            }`}
+          >
+            <button
+              onClick={closeModal}
+              className="absolute top-4 right-4 z-20 bg-white rounded-full w-8 h-8 flex items-center justify-center text-black"
+              aria-label="Close map"
+            >
+              &times;
+            </button>
+            <button
+              onClick={() => setFullscreen((f) => !f)}
+              className="absolute top-4 right-14 z-20 bg-white rounded-full w-8 h-8 flex items-center justify-center text-black"
+              aria-label="Toggle fullscreen"
+            >
+              {fullscreen ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+            </button>
+            <Map
+              coordinates={property.coordinates}
+              title={property.address}
+              price={property.price}
+              className="w-full h-full"
+              zoom={15}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ListingDetail;

--- a/src/pages/listings/index.tsx
+++ b/src/pages/listings/index.tsx
@@ -43,7 +43,7 @@ export const ListingsPage: React.FC = () => {
   };
 
   const handleListingSelect = (id: number) => {
-    setSelected(id);
+    navigate(`/listing/${id}`);
   };
 
   // Pagination


### PR DESCRIPTION
## Summary
- fix map modal to show single instance with fullscreen toggle, spinner, and ESC/outside click close
- drop navigation arrows from listing carousels and extend homepage listings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a512d496d48326a5ebb8ad14b48e6b